### PR TITLE
Fix possibility of multiple progress bars per download

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.util.ThreadUtil;
 
 /**
  * Class that accepts and queues download requests. Download requests are started in background

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -64,12 +64,10 @@ final class DownloadCoordinator {
   private void updateQueue() {
     assert Thread.holdsLock(lock);
 
-    if (activeDownloads.size() < MAX_CONCURRENT_DOWNLOADS) {
-      final DownloadFile downloadFile = pendingDownloads.poll();
-      if (downloadFile != null) {
-        downloadFile.startAsyncDownload(ClientFileSystemHelper.createTempFile());
-        activeDownloads.add(downloadFile);
-      }
+    if (activeDownloads.size() < MAX_CONCURRENT_DOWNLOADS && !pendingDownloads.isEmpty()) {
+      final DownloadFile downloadFile = pendingDownloads.remove();
+      downloadFile.startAsyncDownload(ClientFileSystemHelper.createTempFile());
+      activeDownloads.add(downloadFile);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -40,7 +40,6 @@ final class DownloadCoordinator {
   void accept(final DownloadFileDescription download) {
     synchronized (lock) {
       pendingDownloads.add(new DownloadFile(download, new Listener()));
-      new Thread(() -> downloadListeners.forEach(l -> l.downloadStarted(download))).start();
       updateQueue();
     }
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -23,6 +23,10 @@ final class DownloadFile {
   DownloadFile(final DownloadFileDescription download, final DownloadListener downloadListener) {
     this.download = download;
     this.downloadListener = downloadListener;
+
+    // TODO: consider running in a separate thread because this constructor is called while a lock is held
+    // it works now because the listener calls SwingUtilities.invokeLater(), but that may not always be the case
+    downloadListener.downloadStarted(download);
   }
 
   DownloadFileDescription getDownload() {
@@ -49,8 +53,6 @@ final class DownloadFile {
    */
   private Thread createDownloadThread(final FileSizeWatcher watcher) {
     return new Thread(() -> {
-      downloadListener.downloadStarted(download);
-
       final File fileToDownloadTo = watcher.getFile();
       if (state != DownloadState.CANCELLED) {
         final String url = download.getUrl();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -35,6 +35,7 @@ final class DownloadFile {
    *        file <strong>WILL NOT</strong> be deleted.
    */
   void startAsyncDownload(final File fileToDownloadTo) {
+    new Thread(() -> downloadListener.downloadStarted(download)).start();
     final FileSizeWatcher watcher = new FileSizeWatcher(
         fileToDownloadTo,
         bytesReceived -> downloadListener.downloadUpdated(download, bytesReceived));

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -35,7 +35,6 @@ final class DownloadFile {
    *        file <strong>WILL NOT</strong> be deleted.
    */
   void startAsyncDownload(final File fileToDownloadTo) {
-    new Thread(() -> downloadListener.downloadStarted(download)).start();
     final FileSizeWatcher watcher = new FileSizeWatcher(
         fileToDownloadTo,
         bytesReceived -> downloadListener.downloadUpdated(download, bytesReceived));
@@ -50,6 +49,8 @@ final class DownloadFile {
    */
   private Thread createDownloadThread(final FileSizeWatcher watcher) {
     return new Thread(() -> {
+      downloadListener.downloadStarted(download);
+
       final File fileToDownloadTo = watcher.getFile();
       if (state != DownloadState.CANCELLED) {
         final String url = download.getUrl();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -117,6 +117,15 @@ public class DownloadMapsWindow extends JFrame {
     if (!pendingDownloads.isEmpty()) {
       progressPanel.download(pendingDownloads);
     }
+    // TODO: there is a possibility that pendingDownloads will contain duplicates after the following call.
+    // i don't think it matters, but we should try to avoid it if possible. might be as simply as changing
+    // to a Set.
+    pendingDownloads.addAll(DownloadCoordinator.INSTANCE.getPendingDownloads().stream()
+        .map(DownloadFile::getDownload)
+        .collect(Collectors.toList()));
+    pendingDownloads.addAll(DownloadCoordinator.INSTANCE.getActiveDownloads().stream()
+        .map(DownloadFile::getDownload)
+        .collect(Collectors.toList()));
 
     if (!unknownMapNames.isEmpty()) {
       SwingComponents.newMessageDialog(formatUnknownPendingMapsMessage(unknownMapNames));
@@ -213,8 +222,8 @@ public class DownloadMapsWindow extends JFrame {
         ? null
         : createMapSelectionPanel(selectedMapName, outOfDateDownloads, MapAction.UPDATE);
     // For the UX, always show an available maps tab, even if it is empty
-    final JPanel available = createMapSelectionPanel(selectedMapName, mapList.getAvailable(), MapAction.INSTALL);
-
+    final JPanel available =
+        createMapSelectionPanel(selectedMapName, mapList.getAvailableExcluding(pendingDownloads), MapAction.INSTALL);
 
     // if there is a map to preselect, show the available map list first
     if (selectedMapName.isPresent()) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -443,7 +443,7 @@ public class DownloadMapsWindow extends JFrame {
 
   private ActionListener installAction(final JList<String> gamesList, final List<DownloadFileDescription> maps,
       final DefaultListModel<String> listModel) {
-    return e -> new Thread(() -> {
+    return e -> {
       final List<String> selectedValues = gamesList.getSelectedValuesList();
       final List<DownloadFileDescription> downloadList = new ArrayList<>();
       for (final DownloadFileDescription map : maps) {
@@ -456,6 +456,6 @@ public class DownloadMapsWindow extends JFrame {
       }
 
       downloadList.forEach(m -> listModel.removeElement(m.getMapName()));
-    }).start();
+    };
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -37,6 +37,12 @@ class MapDownloadList {
     return available;
   }
 
+  List<DownloadFileDescription> getAvailableExcluding(final List<DownloadFileDescription> excluded) {
+    return available.stream()
+        .filter(not(excluded::contains))
+        .collect(Collectors.toList());
+  }
+
   List<DownloadFileDescription> getInstalled() {
     return installed;
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -37,6 +37,13 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
   MapDownloadProgressPanel() {
     downloadCoordinator.addDownloadListener(this);
+    addPendingDownloads();
+  }
+
+  private void addPendingDownloads() {
+    downloadCoordinator.getPendingDownloads().stream()
+      .map(DownloadFile::getDownload)
+      .forEach(this::downloadStarted);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -55,10 +55,7 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
   @Override
   public void downloadStarted(final DownloadFileDescription download) {
-    SwingUtilities.invokeLater(() -> {
-      final MapDownloadProgressListener mapDownloadProgressListener = getMapDownloadProgressListenerFor(download);
-      mapDownloadProgressListener.downloadStarted();
-    });
+    SwingUtilities.invokeLater(() -> getMapDownloadProgressListenerFor(download).downloadStarted());
   }
 
   private MapDownloadProgressListener addDownload(final DownloadFileDescription download) {
@@ -98,18 +95,12 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
   @Override
   public void downloadUpdated(final DownloadFileDescription download, final long bytesReceived) {
-    SwingUtilities.invokeLater(() -> {
-      final MapDownloadProgressListener mapDownloadProgressListener = getMapDownloadProgressListenerFor(download);
-      mapDownloadProgressListener.downloadUpdated(bytesReceived);
-    });
+    SwingUtilities.invokeLater(() -> getMapDownloadProgressListenerFor(download).downloadUpdated(bytesReceived));
   }
 
   @Override
   public void downloadStopped(final DownloadFileDescription download) {
-    SwingUtilities.invokeLater(() -> {
-      final MapDownloadProgressListener mapDownloadProgressListener = getMapDownloadProgressListenerFor(download);
-      mapDownloadProgressListener.downloadCompleted();
-    });
+    SwingUtilities.invokeLater(() -> getMapDownloadProgressListenerFor(download).downloadCompleted());
   }
 
   private MapDownloadProgressListener getMapDownloadProgressListenerFor(final DownloadFileDescription download) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -72,8 +72,8 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
     rebuildPanel();
 
-    final MapDownloadProgressListener mapDownloadProgressListener =
-        new MapDownloadProgressListener(download.getUrl(), progressBar, "Installing to: " + download.getInstallLocation().getAbsolutePath());
+    final MapDownloadProgressListener mapDownloadProgressListener = new MapDownloadProgressListener(download.getUrl(),
+        progressBar, "Installing to: " + download.getInstallLocation().getAbsolutePath());
     mapDownloadProgressListeners.put(download, mapDownloadProgressListener);
     mapDownloadProgressListener.downloadStarted();
     return mapDownloadProgressListener;

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -55,7 +55,10 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
   @Override
   public void downloadStarted(final DownloadFileDescription download) {
-    SwingUtilities.invokeLater(() -> addDownload(download));
+    SwingUtilities.invokeLater(() -> {
+      final MapDownloadProgressListener mapDownloadProgressListener = getMapDownloadProgressListenerFor(download);
+      mapDownloadProgressListener.downloadStarted();
+    });
   }
 
   private MapDownloadProgressListener addDownload(final DownloadFileDescription download) {
@@ -72,11 +75,7 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
 
     rebuildPanel();
 
-    final MapDownloadProgressListener mapDownloadProgressListener = new MapDownloadProgressListener(download.getUrl(),
-        progressBar, "Installing to: " + download.getInstallLocation().getAbsolutePath());
-    mapDownloadProgressListeners.put(download, mapDownloadProgressListener);
-    mapDownloadProgressListener.downloadStarted();
-    return mapDownloadProgressListener;
+    return new MapDownloadProgressListener(download, progressBar);
   }
 
   private void rebuildPanel() {

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -56,6 +56,29 @@ public class MapDownloadListTest {
   }
 
   @Test
+  public void testAvailableExcluding() {
+    when(strategy.getMapVersion(any())).thenReturn(Optional.empty());
+    final DownloadFileDescription download1 = newDownloadWithUrl("url1");
+    final DownloadFileDescription download2 = newDownloadWithUrl("url2");
+    final DownloadFileDescription download3 = newDownloadWithUrl("url3");
+    final MapDownloadList testObj = new MapDownloadList(Arrays.asList(download1, download2, download3), strategy);
+
+    final List<DownloadFileDescription> available = testObj.getAvailableExcluding(Arrays.asList(download1, download3));
+
+    assertThat(available, is(Arrays.asList(download2)));
+  }
+
+  private static DownloadFileDescription newDownloadWithUrl(final String url) {
+    return new DownloadFileDescription(
+        url,
+        "description",
+        "mapName",
+        MAP_VERSION,
+        DownloadFileDescription.DownloadType.MAP,
+        DownloadFileDescription.MapCategory.BEST);
+  }
+
+  @Test
   public void testInstalled() {
     when(strategy.getMapVersion(any())).thenReturn(Optional.of(MAP_VERSION));
     final MapDownloadList testObj = new MapDownloadList(descriptions, strategy);
@@ -96,15 +119,5 @@ public class MapDownloadListTest {
     final List<DownloadFileDescription> outOfDate = testObj.getOutOfDateExcluding(Arrays.asList(download1, download3));
 
     assertThat(outOfDate, is(Arrays.asList(download2)));
-  }
-
-  private static DownloadFileDescription newDownloadWithUrl(final String url) {
-    return new DownloadFileDescription(
-        url,
-        "description",
-        "mapName",
-        MAP_VERSION,
-        DownloadFileDescription.DownloadType.MAP,
-        DownloadFileDescription.MapCategory.BEST);
   }
 }


### PR DESCRIPTION
The problem was due to moving the call to `DownloadListener#downloadStarted()` from `DownloadFile#startAsyncDownload()` to `DownloadCoordinator#accept()`.

When called from `DownloadFile#startAsyncDownload()`, `downloadStarted()` will only be invoked once per download.  However, the code in `DownloadCoordinator#accept()` was calling downloadStarted() for each listener every time a new download was started.  This had the side effect of creating additional progress bars for in-progress downloads whenever a new download was started.

I simply restored the previous code where `downloadStarted()` is called from `DownloadFile#startAsyncDownload()`.  If there was a reason this code was moved to `DownloadCoordinator#accept()`, it should be re-evaluated.

I also fixed a Checkstyle regression so my Gradle build completed without error. :smile: