### PR TITLE
Throw custom exception type from MutableProperty setter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -74,7 +74,15 @@ public class ChangeAttachmentChange extends Change {
     if (clearFirst) {
       attachmentProperty.resetValue();
     }
-    attachmentProperty.setObjectValue(newValue);
+    try {
+      attachmentProperty.setValue(newValue);
+    } catch (final MutableProperty.InvalidValueException e) {
+      throw new IllegalStateException(
+          String.format(
+              "failed to set value '%s' on property '%s' for attachment '%s' associated with '%s'",
+              newValue, property, attachmentName, attachedTo),
+          e);
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IAttachment;
+import games.strategy.engine.data.MutableProperty;
 
 class AttachmentPropertyResetUndo extends Change {
   private static final long serialVersionUID = 5943939650116851332L;
@@ -31,7 +32,15 @@ class AttachmentPropertyResetUndo extends Change {
   @Override
   public void perform(final GameData data) {
     final IAttachment attachment = m_attachedTo.getAttachment(m_attachmentName);
-    attachment.getPropertyOrThrow(m_property).setObjectValue(m_newValue);
+    try {
+      attachment.getPropertyOrThrow(m_property).setValue(m_newValue);
+    } catch (final MutableProperty.InvalidValueException e) {
+      throw new IllegalStateException(
+          String.format(
+              "failed to set value '%s' on property '%s' for attachment '%s' associated with '%s'",
+              m_newValue, m_property, m_attachmentName, m_attachedTo),
+          e);
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -5,6 +5,7 @@ import java.io.ObjectInputStream;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
 
 public class ObjectPropertyChange extends Change {
@@ -42,7 +43,15 @@ public class ObjectPropertyChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    m_object.getPropertyOrThrow(m_property).setObjectValue(m_newValue);
+    try {
+      m_object.getPropertyOrThrow(m_property).setValue(m_newValue);
+    } catch (final MutableProperty.InvalidValueException e) {
+      throw new IllegalStateException(
+          String.format(
+              "failed to set value '%s' on property '%s' for object '%s'",
+              m_newValue, m_property, m_object),
+          e);
+    }
   }
 
   @Override


### PR DESCRIPTION
This is a baby step that addresses the public methods of `MutableProperty` throwing `Exception`.  The idea being that new APIs we write shouldn't be forced to be suboptimal because of the forces exerted by surrounding legacy code.

In calling code, where `InvalidValueException` is handled, I preserved the legacy `PropertyUtil` behavior of throwing `IllegalStateException`.

I made `setValue(String)` and `setValue(T)` private for now, as it seemed clearer to give callers a single choice via `setValue(Object)`.  I renamed those methods to make that clear.  Let me know if you disagree.  If you do think callers should be able to get to `setValue(String)` directly (for performance or whatever), I would recommend we change the name of that method to something like `parseAndSetValue(String)` to better distinguish its behavior from `setValue(T)`.

I have a few other ideas I'm going to try out in separate PRs.