### PR TITLE
Add property type

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -150,6 +150,51 @@ public final class MutableProperty<T> {
   }
 
   /**
+   * Convenience method to create a generic read-write Boolean instance of this interface.
+   */
+  public static MutableProperty<Boolean> ofBoolean(
+      final ThrowingConsumer<Boolean, Exception> setter,
+      final ThrowingConsumer<String, Exception> stringSetter,
+      final Supplier<Boolean> getter,
+      final Runnable resetter) {
+    return of(Boolean.class, setter, stringSetter, getter, resetter);
+  }
+
+  /**
+   * Convenience method to create a generic read-only Boolean instance of this interface.
+   */
+  public static MutableProperty<Boolean> ofReadOnlyBoolean(final Supplier<Boolean> getter) {
+    return of(Boolean.class, noSetter(), noStringSetter(), getter, noResetter());
+  }
+
+  /**
+   * Convenience method to create a generic write-only Boolean instance of this interface.
+   */
+  public static MutableProperty<Boolean> ofWriteOnlyBoolean(
+      final ThrowingConsumer<Boolean, Exception> setter,
+      final ThrowingConsumer<String, Exception> stringSetter) {
+    return of(Boolean.class, setter, stringSetter, noGetter(), noResetter());
+  }
+
+  /**
+   * Convenience method to create a generic read-write Integer instance of this interface.
+   */
+  public static MutableProperty<Integer> ofInteger(
+      final ThrowingConsumer<Integer, Exception> setter,
+      final ThrowingConsumer<String, Exception> stringSetter,
+      final Supplier<Integer> getter,
+      final Runnable resetter) {
+    return of(Integer.class, setter, stringSetter, getter, resetter);
+  }
+
+  /**
+   * Convenience method to create a generic read-only Integer instance of this interface.
+   */
+  public static MutableProperty<Integer> ofReadOnlyInteger(final Supplier<Integer> getter) {
+    return of(Integer.class, noSetter(), noStringSetter(), getter, noResetter());
+  }
+
+  /**
    * Convenience method to create a generic String instance of this interface.
    */
   public static MutableProperty<String> ofString(
@@ -176,6 +221,26 @@ public final class MutableProperty<T> {
    */
   public static <T> MutableProperty<T> ofSimple(final Class<T> type, final Supplier<T> getter) {
     return ofSimple(type, noSetter(), getter);
+  }
+
+  /**
+   * Convenience method to create an instance of this interface that just contains a direct
+   * setter and getter for a Boolean. And no support for Strings as secondary setter.
+   */
+  public static MutableProperty<Boolean> ofSimpleBoolean(
+      final ThrowingConsumer<Boolean, Exception> setter,
+      final Supplier<Boolean> getter) {
+    return of(Boolean.class, setter, noStringSetter(), getter, noResetter());
+  }
+
+  /**
+   * Convenience method to create an instance of this interface that just contains a direct
+   * setter and getter for an Integer. And no support for Strings as secondary setter.
+   */
+  public static MutableProperty<Integer> ofSimpleInteger(
+      final ThrowingConsumer<Integer, Exception> setter,
+      final Supplier<Integer> getter) {
+    return of(Integer.class, setter, noStringSetter(), getter, noResetter());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -87,17 +87,17 @@ public final class MutableProperty<T> {
     if (value instanceof String) {
       setStringValue((String) value);
     } else {
-      final T typedValue;
-      try {
-        typedValue = type.cast(value);
-      } catch (final ClassCastException e) {
-        throw new InvalidValueException(
-            String.format(
-                "failed to set property value; expected value of type '%s' but was '%s'", type,
-                value.getClass()),
-            e);
-      }
-      setTypedValue(typedValue);
+      setTypedValue(cast(value));
+    }
+  }
+
+  private T cast(final Object value) throws InvalidValueException {
+    try {
+      return type.cast(value);
+    } catch (final ClassCastException e) {
+      throw new InvalidValueException(
+          String.format("expected value of type '%s' but was '%s'", type, value.getClass()),
+          e);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -155,8 +155,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
                 this::getOwner))
         .put("uid", MutableProperty.ofSimple(GUID.class, this::getId))
         .put("hits",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setHits,
                 this::getHits))
         .put("type", MutableProperty.ofSimple(UnitType.class, this::getType))

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -150,14 +150,16 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("owner",
             MutableProperty.ofSimple(
+                PlayerID.class,
                 this::setOwner,
                 this::getOwner))
-        .put("uid", MutableProperty.ofSimple(this::getId))
+        .put("uid", MutableProperty.ofSimple(GUID.class, this::getId))
         .put("hits",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setHits,
                 this::getHits))
-        .put("type", MutableProperty.ofSimple(this::getType))
+        .put("type", MutableProperty.ofSimple(UnitType.class, this::getType))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -532,8 +532,7 @@ public class TripleAUnit extends Unit {
                 this::setUnloaded,
                 this::getUnloaded))
         .put("wasLoadedThisTurn",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasLoadedThisTurn,
                 this::getWasLoadedThisTurn))
         .put("unloadedTo",
@@ -542,28 +541,23 @@ public class TripleAUnit extends Unit {
                 this::setUnloadedTo,
                 this::getUnloadedTo))
         .put("wasUnloadedInCombatPhase",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasUnloadedInCombatPhase,
                 this::getWasUnloadedInCombatPhase))
         .put("alreadyMoved",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setAlreadyMoved,
                 this::getAlreadyMoved))
         .put("bonusMovement",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setBonusMovement,
                 this::getBonusMovement))
         .put("unitDamage",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setUnitDamage,
                 this::getUnitDamage))
         .put("submerged",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setSubmerged,
                 this::getSubmerged))
         .put("originalOwner",
@@ -572,18 +566,15 @@ public class TripleAUnit extends Unit {
                 this::setOriginalOwner,
                 this::getOriginalOwner))
         .put("wasInCombat",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasInCombat,
                 this::getWasInCombat))
         .put("wasLoadedAfterCombat",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasLoadedAfterCombat,
                 this::getWasLoadedAfterCombat))
         .put("wasAmphibious",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasAmphibious,
                 this::getWasAmphibious))
         .put("originatedFrom",
@@ -592,33 +583,27 @@ public class TripleAUnit extends Unit {
                 this::setOriginatedFrom,
                 this::getOriginatedFrom))
         .put("wasScrambled",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasScrambled,
                 this::getWasScrambled))
         .put("maxScrambleCount",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount))
         .put("wasInAirBattle",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setWasInAirBattle,
                 this::getWasInAirBattle))
         .put("disabled",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setDisabled,
                 this::getDisabled))
         .put("launched",
-            MutableProperty.ofSimple(
-                Integer.class,
+            MutableProperty.ofSimpleInteger(
                 this::setLaunched,
                 this::getLaunched))
         .put("airborne",
-            MutableProperty.ofSimple(
-                Boolean.class,
+            MutableProperty.ofSimpleBoolean(
                 this::setAirborne,
                 this::getAirborne))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -523,82 +523,102 @@ public class TripleAUnit extends Unit {
         .putAll(super.getPropertyMap())
         .put("transportedBy",
             MutableProperty.ofSimple(
+                TripleAUnit.class,
                 this::setTransportedBy,
                 this::getTransportedBy))
         .put("unloaded",
             MutableProperty.ofSimple(
+                List.class,
                 this::setUnloaded,
                 this::getUnloaded))
         .put("wasLoadedThisTurn",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasLoadedThisTurn,
                 this::getWasLoadedThisTurn))
         .put("unloadedTo",
             MutableProperty.ofSimple(
+                Territory.class,
                 this::setUnloadedTo,
                 this::getUnloadedTo))
         .put("wasUnloadedInCombatPhase",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasUnloadedInCombatPhase,
                 this::getWasUnloadedInCombatPhase))
         .put("alreadyMoved",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setAlreadyMoved,
                 this::getAlreadyMoved))
         .put("bonusMovement",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setBonusMovement,
                 this::getBonusMovement))
         .put("unitDamage",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setUnitDamage,
                 this::getUnitDamage))
         .put("submerged",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setSubmerged,
                 this::getSubmerged))
         .put("originalOwner",
             MutableProperty.ofSimple(
+                PlayerID.class,
                 this::setOriginalOwner,
                 this::getOriginalOwner))
         .put("wasInCombat",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasInCombat,
                 this::getWasInCombat))
         .put("wasLoadedAfterCombat",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasLoadedAfterCombat,
                 this::getWasLoadedAfterCombat))
         .put("wasAmphibious",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasAmphibious,
                 this::getWasAmphibious))
         .put("originatedFrom",
             MutableProperty.ofSimple(
+                Territory.class,
                 this::setOriginatedFrom,
                 this::getOriginatedFrom))
         .put("wasScrambled",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasScrambled,
                 this::getWasScrambled))
         .put("maxScrambleCount",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount))
         .put("wasInAirBattle",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setWasInAirBattle,
                 this::getWasInAirBattle))
         .put("disabled",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setDisabled,
                 this::getDisabled))
         .put("launched",
             MutableProperty.ofSimple(
+                Integer.class,
                 this::setLaunched,
                 this::getLaunched))
         .put("airborne",
             MutableProperty.ofSimple(
+                Boolean.class,
                 this::setAirborne,
                 this::getAirborne))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -401,36 +401,38 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("conditions",
             MutableProperty.of(
+                List.class,
                 this::setConditions,
                 this::setConditions,
                 this::getConditions,
                 this::resetConditions))
         .put("conditionType",
-            MutableProperty.of(
-                this::setConditionType,
+            MutableProperty.ofString(
                 this::setConditionType,
                 this::getConditionType,
                 this::resetConditionType))
         .put("invert",
             MutableProperty.of(
+                Boolean.class,
                 this::setInvert,
                 this::setInvert,
                 this::getInvert,
                 this::resetInvert))
         .put("chance",
-            MutableProperty.of(
-                this::setChance,
+            MutableProperty.ofString(
                 this::setChance,
                 this::getChance,
                 this::resetChance))
         .put("chanceIncrementOnFailure",
             MutableProperty.of(
+                Integer.class,
                 this::setChanceIncrementOnFailure,
                 this::setChanceIncrementOnFailure,
                 this::getChanceIncrementOnFailure,
                 this::resetChanceIncrementOnFailure))
         .put("chanceDecrementOnSuccess",
             MutableProperty.of(
+                Integer.class,
                 this::setChanceDecrementOnSuccess,
                 this::setChanceDecrementOnSuccess,
                 this::getChanceDecrementOnSuccess,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -412,8 +412,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::getConditionType,
                 this::resetConditionType))
         .put("invert",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setInvert,
                 this::setInvert,
                 this::getInvert,
@@ -424,15 +423,13 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::getChance,
                 this::resetChance))
         .put("chanceIncrementOnFailure",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setChanceIncrementOnFailure,
                 this::setChanceIncrementOnFailure,
                 this::getChanceIncrementOnFailure,
                 this::resetChanceIncrementOnFailure))
         .put("chanceDecrementOnSuccess",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setChanceDecrementOnSuccess,
                 this::setChanceDecrementOnSuccess,
                 this::getChanceDecrementOnSuccess,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -351,50 +351,43 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
                 this::getMovementRestrictionTerritories,
                 this::resetMovementRestrictionTerritories))
         .put("placementAnyTerritory",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setPlacementAnyTerritory,
                 this::setPlacementAnyTerritory,
                 this::getPlacementAnyTerritory,
                 this::resetPlacementAnyTerritory))
         .put("placementAnySeaZone",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setPlacementAnySeaZone,
                 this::setPlacementAnySeaZone,
                 this::getPlacementAnySeaZone,
                 this::resetPlacementAnySeaZone))
         .put("placementCapturedTerritory",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setPlacementCapturedTerritory,
                 this::setPlacementCapturedTerritory,
                 this::getPlacementCapturedTerritory,
                 this::resetPlacementCapturedTerritory))
         .put("unlimitedProduction",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setUnlimitedProduction,
                 this::setUnlimitedProduction,
                 this::getUnlimitedProduction,
                 this::resetUnlimitedProduction))
         .put("placementInCapitalRestricted",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setPlacementInCapitalRestricted,
                 this::setPlacementInCapitalRestricted,
                 this::getPlacementInCapitalRestricted,
                 this::resetPlacementInCapitalRestricted))
         .put("dominatingFirstRoundAttack",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setDominatingFirstRoundAttack,
                 this::setDominatingFirstRoundAttack,
                 this::getDominatingFirstRoundAttack,
                 this::resetDominatingFirstRoundAttack))
         .put("negateDominatingFirstRoundAttack",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setNegateDominatingFirstRoundAttack,
                 this::setNegateDominatingFirstRoundAttack,
                 this::getNegateDominatingFirstRoundAttack,
@@ -407,15 +400,13 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
                 this::getProductionPerXTerritories,
                 this::resetProductionPerXTerritories))
         .put("placementPerTerritory",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setPlacementPerTerritory,
                 this::setPlacementPerTerritory,
                 this::getPlacementPerTerritory,
                 this::resetPlacementPerTerritory))
         .put("maxPlacePerTerritory",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxPlacePerTerritory,
                 this::setMaxPlacePerTerritory,
                 this::getMaxPlacePerTerritory,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -339,73 +339,83 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("movementRestrictionType",
-            MutableProperty.of(
-                this::setMovementRestrictionType,
+            MutableProperty.ofString(
                 this::setMovementRestrictionType,
                 this::getMovementRestrictionType,
                 this::resetMovementRestrictionType))
         .put("movementRestrictionTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setMovementRestrictionTerritories,
                 this::setMovementRestrictionTerritories,
                 this::getMovementRestrictionTerritories,
                 this::resetMovementRestrictionTerritories))
         .put("placementAnyTerritory",
             MutableProperty.of(
+                Boolean.class,
                 this::setPlacementAnyTerritory,
                 this::setPlacementAnyTerritory,
                 this::getPlacementAnyTerritory,
                 this::resetPlacementAnyTerritory))
         .put("placementAnySeaZone",
             MutableProperty.of(
+                Boolean.class,
                 this::setPlacementAnySeaZone,
                 this::setPlacementAnySeaZone,
                 this::getPlacementAnySeaZone,
                 this::resetPlacementAnySeaZone))
         .put("placementCapturedTerritory",
             MutableProperty.of(
+                Boolean.class,
                 this::setPlacementCapturedTerritory,
                 this::setPlacementCapturedTerritory,
                 this::getPlacementCapturedTerritory,
                 this::resetPlacementCapturedTerritory))
         .put("unlimitedProduction",
             MutableProperty.of(
+                Boolean.class,
                 this::setUnlimitedProduction,
                 this::setUnlimitedProduction,
                 this::getUnlimitedProduction,
                 this::resetUnlimitedProduction))
         .put("placementInCapitalRestricted",
             MutableProperty.of(
+                Boolean.class,
                 this::setPlacementInCapitalRestricted,
                 this::setPlacementInCapitalRestricted,
                 this::getPlacementInCapitalRestricted,
                 this::resetPlacementInCapitalRestricted))
         .put("dominatingFirstRoundAttack",
             MutableProperty.of(
+                Boolean.class,
                 this::setDominatingFirstRoundAttack,
                 this::setDominatingFirstRoundAttack,
                 this::getDominatingFirstRoundAttack,
                 this::resetDominatingFirstRoundAttack))
         .put("negateDominatingFirstRoundAttack",
             MutableProperty.of(
+                Boolean.class,
                 this::setNegateDominatingFirstRoundAttack,
                 this::setNegateDominatingFirstRoundAttack,
                 this::getNegateDominatingFirstRoundAttack,
                 this::resetNegateDominatingFirstRoundAttack))
         .put("productionPerXTerritories",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setProductionPerXTerritories,
                 this::setProductionPerXTerritories,
                 this::getProductionPerXTerritories,
                 this::resetProductionPerXTerritories))
         .put("placementPerTerritory",
             MutableProperty.of(
+                Integer.class,
                 this::setPlacementPerTerritory,
                 this::setPlacementPerTerritory,
                 this::getPlacementPerTerritory,
                 this::resetPlacementPerTerritory))
         .put("maxPlacePerTerritory",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxPlacePerTerritory,
                 this::setMaxPlacePerTerritory,
                 this::getMaxPlacePerTerritory,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -438,8 +438,8 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
-        .put("countEach", MutableProperty.of(Boolean.class, this::getCountEach))
-        .put("eachMultiple", MutableProperty.of(Integer.class, this::getEachMultiple))
+        .put("countEach", MutableProperty.ofReadOnlyBoolean(this::getCountEach))
+        .put("eachMultiple", MutableProperty.ofReadOnlyInteger(this::getEachMultiple))
         .put("players",
             MutableProperty.of(
                 List.class,
@@ -448,15 +448,13 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
                 this::getPlayers,
                 this::resetPlayers))
         .put("objectiveValue",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setObjectiveValue,
                 this::setObjectiveValue,
                 this::getObjectiveValue,
                 this::resetObjectiveValue))
         .put("uses",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setUses,
                 this::setUses,
                 this::getUses,
@@ -469,8 +467,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
                 this::getTurns,
                 this::resetTurns))
         .put("switch",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setSwitch,
                 this::setSwitch,
                 this::getSwitch,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -438,45 +438,49 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
-        .put("countEach", MutableProperty.of(this::getCountEach))
-        .put("eachMultiple", MutableProperty.of(this::getEachMultiple))
+        .put("countEach", MutableProperty.of(Boolean.class, this::getCountEach))
+        .put("eachMultiple", MutableProperty.of(Integer.class, this::getEachMultiple))
         .put("players",
             MutableProperty.of(
+                List.class,
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("objectiveValue",
             MutableProperty.of(
+                Integer.class,
                 this::setObjectiveValue,
                 this::setObjectiveValue,
                 this::getObjectiveValue,
                 this::resetObjectiveValue))
         .put("uses",
             MutableProperty.of(
+                Integer.class,
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("turns",
             MutableProperty.of(
+                Map.class,
                 this::setTurns,
                 this::setTurns,
                 this::getTurns,
                 this::resetTurns))
         .put("switch",
             MutableProperty.of(
+                Boolean.class,
                 this::setSwitch,
                 this::setSwitch,
                 this::getSwitch,
                 this::resetSwitch))
         .put("gameProperty",
-            MutableProperty.of(
-                this::setGameProperty,
+            MutableProperty.ofString(
                 this::setGameProperty,
                 this::getGameProperty,
                 this::resetGameProperty))
-        .put("rounds", MutableProperty.of(this::setRounds, this::setRounds))
+        .put("rounds", MutableProperty.of(String.class, this::setRounds, this::setRounds))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -315,30 +315,33 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
         .putAll(super.getPropertyMap())
         .put("uses",
             MutableProperty.of(
+                Integer.class,
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("usedThisRound",
             MutableProperty.of(
+                Boolean.class,
                 this::setUsedThisRound,
                 this::setUsedThisRound,
                 this::getUsedThisRound,
                 this::resetUsedThisRound))
         .put("notification",
-            MutableProperty.of(
-                this::setNotification,
+            MutableProperty.ofString(
                 this::setNotification,
                 this::getNotification,
                 this::resetNotification))
         .put("when",
             MutableProperty.of(
+                List.class,
                 this::setWhen,
                 this::setWhen,
                 this::getWhen,
                 this::resetWhen))
         .put("trigger",
             MutableProperty.of(
+                List.class,
                 l -> {
                   throw new IllegalStateException("Can't set trigger directly");
                 },

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -314,15 +314,13 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("uses",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("usedThisRound",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setUsedThisRound,
                 this::setUsedThisRound,
                 this::getUsedThisRound,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -214,31 +214,34 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("text",
-            MutableProperty.of(
-                this::setText,
+            MutableProperty.ofString(
                 this::setText,
                 this::getText,
                 this::resetText))
         .put("costPU",
             MutableProperty.of(
+                Integer.class,
                 this::setCostPU,
                 this::setCostPU,
                 this::getCostPU,
                 this::resetCostPU))
         .put("attemptsPerTurn",
             MutableProperty.of(
+                Integer.class,
                 this::setAttemptsPerTurn,
                 this::setAttemptsPerTurn,
                 this::getAttemptsPerTurn,
                 this::resetAttemptsPerTurn))
         .put("attemptsLeftThisTurn",
             MutableProperty.of(
+                Integer.class,
                 this::setAttemptsLeftThisTurn,
                 this::setAttemptsLeftThisTurn,
                 this::getAttemptsLeftThisTurn,
                 this::resetAttemptsLeftThisTurn))
         .put("actionAccept",
             MutableProperty.of(
+                List.class,
                 this::setActionAccept,
                 this::setActionAccept,
                 this::getActionAccept,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -219,22 +219,19 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
                 this::getText,
                 this::resetText))
         .put("costPU",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCostPU,
                 this::setCostPU,
                 this::getCostPU,
                 this::resetCostPU))
         .put("attemptsPerTurn",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttemptsPerTurn,
                 this::setAttemptsPerTurn,
                 this::getAttemptsPerTurn,
                 this::resetAttemptsPerTurn))
         .put("attemptsLeftThisTurn",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttemptsLeftThisTurn,
                 this::setAttemptsLeftThisTurn,
                 this::getAttemptsLeftThisTurn,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -175,12 +175,14 @@ public class CanalAttachment extends DefaultAttachment {
         .put("canalName", MutableProperty.ofString(this::setCanalName, this::getCanalName, this::resetCanalName))
         .put("landTerritories",
             MutableProperty.of(
+                Set.class,
                 this::setLandTerritories,
                 this::setLandTerritories,
                 this::getLandTerritories,
                 this::resetLandTerritories))
         .put("excludedUnits",
             MutableProperty.of(
+                Set.class,
                 this::setExcludedUnits,
                 this::setExcludedUnits,
                 this::getExcludedUnits,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -599,29 +599,25 @@ public class PlayerAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("vps",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setVps,
                 this::setVps,
                 this::getVps,
                 this::resetVps))
         .put("captureVps",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCaptureVps,
                 this::setCaptureVps,
                 this::getCaptureVps,
                 this::resetCaptureVps))
         .put("retainCapitalNumber",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setRetainCapitalNumber,
                 this::setRetainCapitalNumber,
                 this::getRetainCapitalNumber,
                 this::resetRetainCapitalNumber))
         .put("retainCapitalProduceNumber",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setRetainCapitalProduceNumber,
                 this::setRetainCapitalProduceNumber,
                 this::getRetainCapitalProduceNumber,
@@ -655,15 +651,13 @@ public class PlayerAttachment extends DefaultAttachment {
                 this::getHelpPayTechCost,
                 this::resetHelpPayTechCost))
         .put("destroysPUs",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setDestroysPUs,
                 this::setDestroysPUs,
                 this::getDestroysPUs,
                 this::resetDestroysPUs))
         .put("immuneToBlockade",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setImmuneToBlockade,
                 this::setImmuneToBlockade,
                 this::getImmuneToBlockade,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -598,87 +598,107 @@ public class PlayerAttachment extends DefaultAttachment {
   @Override
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put("vps", MutableProperty.of(this::setVps, this::setVps, this::getVps, this::resetVps))
+        .put("vps",
+            MutableProperty.of(
+                Integer.class,
+                this::setVps,
+                this::setVps,
+                this::getVps,
+                this::resetVps))
         .put("captureVps",
             MutableProperty.of(
+                Integer.class,
                 this::setCaptureVps,
                 this::setCaptureVps,
                 this::getCaptureVps,
                 this::resetCaptureVps))
         .put("retainCapitalNumber",
             MutableProperty.of(
+                Integer.class,
                 this::setRetainCapitalNumber,
                 this::setRetainCapitalNumber,
                 this::getRetainCapitalNumber,
                 this::resetRetainCapitalNumber))
         .put("retainCapitalProduceNumber",
             MutableProperty.of(
+                Integer.class,
                 this::setRetainCapitalProduceNumber,
                 this::setRetainCapitalProduceNumber,
                 this::getRetainCapitalProduceNumber,
                 this::resetRetainCapitalProduceNumber))
         .put("giveUnitControl",
             MutableProperty.of(
+                List.class,
                 this::setGiveUnitControl,
                 this::setGiveUnitControl,
                 this::getGiveUnitControl,
                 this::resetGiveUnitControl))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
+                List.class,
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("shareTechnology",
             MutableProperty.of(
+                List.class,
                 this::setShareTechnology,
                 this::setShareTechnology,
                 this::getShareTechnology,
                 this::resetShareTechnology))
         .put("helpPayTechCost",
             MutableProperty.of(
+                List.class,
                 this::setHelpPayTechCost,
                 this::setHelpPayTechCost,
                 this::getHelpPayTechCost,
                 this::resetHelpPayTechCost))
         .put("destroysPUs",
             MutableProperty.of(
+                Boolean.class,
                 this::setDestroysPUs,
                 this::setDestroysPUs,
                 this::getDestroysPUs,
                 this::resetDestroysPUs))
         .put("immuneToBlockade",
             MutableProperty.of(
+                Boolean.class,
                 this::setImmuneToBlockade,
                 this::setImmuneToBlockade,
                 this::getImmuneToBlockade,
                 this::resetImmuneToBlockade))
         .put("suicideAttackResources",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setSuicideAttackResources,
                 this::setSuicideAttackResources,
                 this::getSuicideAttackResources,
                 this::resetSuicideAttackResources))
         .put("suicideAttackTargets",
             MutableProperty.of(
+                Set.class,
                 this::setSuicideAttackTargets,
                 this::setSuicideAttackTargets,
                 this::getSuicideAttackTargets,
                 this::resetSuicideAttackTargets))
         .put("placementLimit",
             MutableProperty.of(
+                Set.class,
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("movementLimit",
             MutableProperty.of(
+                Set.class,
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attackingLimit",
             MutableProperty.of(
+                Set.class,
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -157,6 +157,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
         .putAll(super.getPropertyMap())
         .put("relationshipChange",
             MutableProperty.of(
+                List.class,
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -414,74 +414,62 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("archeType",
-            MutableProperty.of(
-                this::setArcheType,
+            MutableProperty.ofString(
                 this::setArcheType,
                 this::getArcheType,
                 this::resetArcheType))
         .put("canMoveLandUnitsOverOwnedLand",
-            MutableProperty.of(
-                this::setCanMoveLandUnitsOverOwnedLand,
+            MutableProperty.ofString(
                 this::setCanMoveLandUnitsOverOwnedLand,
                 this::getCanMoveLandUnitsOverOwnedLand,
                 this::resetCanMoveLandUnitsOverOwnedLand))
         .put("canMoveAirUnitsOverOwnedLand",
-            MutableProperty.of(
-                this::setCanMoveAirUnitsOverOwnedLand,
+            MutableProperty.ofString(
                 this::setCanMoveAirUnitsOverOwnedLand,
                 this::getCanMoveAirUnitsOverOwnedLand,
                 this::resetCanMoveAirUnitsOverOwnedLand))
         .put("alliancesCanChainTogether",
-            MutableProperty.of(
-                this::setAlliancesCanChainTogether,
+            MutableProperty.ofString(
                 this::setAlliancesCanChainTogether,
                 this::getAlliancesCanChainTogether,
                 this::resetAlliancesCanChainTogether))
         .put("isDefaultWarPosition",
-            MutableProperty.of(
-                this::setIsDefaultWarPosition,
+            MutableProperty.ofString(
                 this::setIsDefaultWarPosition,
                 this::getIsDefaultWarPosition,
                 this::resetIsDefaultWarPosition))
         .put("upkeepCost",
-            MutableProperty.of(
-                this::setUpkeepCost,
+            MutableProperty.ofString(
                 this::setUpkeepCost,
                 this::getUpkeepCost,
                 this::resetUpkeepCost))
         .put("canLandAirUnitsOnOwnedLand",
-            MutableProperty.of(
-                this::setCanLandAirUnitsOnOwnedLand,
+            MutableProperty.ofString(
                 this::setCanLandAirUnitsOnOwnedLand,
                 this::getCanLandAirUnitsOnOwnedLand,
                 this::resetCanLandAirUnitsOnOwnedLand))
         .put("canTakeOverOwnedTerritory",
-            MutableProperty.of(
-                this::setCanTakeOverOwnedTerritory,
+            MutableProperty.ofString(
                 this::setCanTakeOverOwnedTerritory,
                 this::getCanTakeOverOwnedTerritory,
                 this::resetCanTakeOverOwnedTerritory))
         .put("givesBackOriginalTerritories",
-            MutableProperty.of(
-                this::setGivesBackOriginalTerritories,
+            MutableProperty.ofString(
                 this::setGivesBackOriginalTerritories,
                 this::getGivesBackOriginalTerritories,
                 this::resetGivesBackOriginalTerritories))
         .put("canMoveIntoDuringCombatMove",
-            MutableProperty.of(
-                this::setCanMoveIntoDuringCombatMove,
+            MutableProperty.ofString(
                 this::setCanMoveIntoDuringCombatMove,
                 this::getCanMoveIntoDuringCombatMove,
                 this::resetCanMoveIntoDuringCombatMove))
         .put("canMoveThroughCanals",
-            MutableProperty.of(
-                this::setCanMoveThroughCanals,
+            MutableProperty.ofString(
                 this::setCanMoveThroughCanals,
                 this::getCanMoveThroughCanals,
                 this::resetCanMoveThroughCanals))
         .put("rocketsCanFlyOver",
-            MutableProperty.of(
-                this::setRocketsCanFlyOver,
+            MutableProperty.ofString(
                 this::setRocketsCanFlyOver,
                 this::getRocketsCanFlyOver,
                 this::resetRocketsCanFlyOver))

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1176,7 +1176,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
                 this::getTechs,
                 this::resetTechs))
         .put("techCount",
-            MutableProperty.of(Integer.class, this::getTechCount))
+            MutableProperty.ofReadOnlyInteger(this::getTechCount))
         .put("relationship",
             MutableProperty.of(
                 List.class,
@@ -1192,7 +1192,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
                 this::getAtWarPlayers,
                 this::resetAtWarPlayers))
         .put("atWarCount",
-            MutableProperty.of(Integer.class, this::getAtWarCount))
+            MutableProperty.ofReadOnlyInteger(this::getAtWarCount))
         .put("destroyedTUV",
             MutableProperty.ofString(
                 this::setDestroyedTUV,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1170,94 +1170,107 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         .putAll(super.getPropertyMap())
         .put("techs",
             MutableProperty.of(
+                List.class,
                 this::setTechs,
                 this::setTechs,
                 this::getTechs,
                 this::resetTechs))
         .put("techCount",
-            MutableProperty.of(this::getTechCount))
+            MutableProperty.of(Integer.class, this::getTechCount))
         .put("relationship",
             MutableProperty.of(
+                List.class,
                 this::setRelationship,
                 this::setRelationship,
                 this::getRelationship,
                 this::resetRelationship))
         .put("atWarPlayers",
             MutableProperty.of(
+                Set.class,
                 this::setAtWarPlayers,
                 this::setAtWarPlayers,
                 this::getAtWarPlayers,
                 this::resetAtWarPlayers))
         .put("atWarCount",
-            MutableProperty.of(this::getAtWarCount))
+            MutableProperty.of(Integer.class, this::getAtWarCount))
         .put("destroyedTUV",
-            MutableProperty.of(
-                this::setDestroyedTUV,
+            MutableProperty.ofString(
                 this::setDestroyedTUV,
                 this::getDestroyedTUV,
                 this::resetDestroyedTUV))
         .put("battle",
             MutableProperty.of(
+                List.class,
                 this::setBattle,
                 this::setBattle,
                 this::getBattle,
                 this::resetBattle))
         .put("alliedOwnershipTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setAlliedOwnershipTerritories,
                 this::setAlliedOwnershipTerritories,
                 this::getAlliedOwnershipTerritories,
                 this::resetAlliedOwnershipTerritories))
         .put("directOwnershipTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setDirectOwnershipTerritories,
                 this::setDirectOwnershipTerritories,
                 this::getDirectOwnershipTerritories,
                 this::resetDirectOwnershipTerritories))
         .put("alliedExclusionTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setAlliedExclusionTerritories,
                 this::setAlliedExclusionTerritories,
                 this::getAlliedExclusionTerritories,
                 this::resetAlliedExclusionTerritories))
         .put("directExclusionTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setDirectExclusionTerritories,
                 this::setDirectExclusionTerritories,
                 this::getDirectExclusionTerritories,
                 this::resetDirectExclusionTerritories))
         .put("enemyExclusionTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setEnemyExclusionTerritories,
                 this::setEnemyExclusionTerritories,
                 this::getEnemyExclusionTerritories,
                 this::resetEnemyExclusionTerritories))
         .put("enemySurfaceExclusionTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setEnemySurfaceExclusionTerritories,
                 this::setEnemySurfaceExclusionTerritories,
                 this::getEnemySurfaceExclusionTerritories,
                 this::resetEnemySurfaceExclusionTerritories))
         .put("directPresenceTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setDirectPresenceTerritories,
                 this::setDirectPresenceTerritories,
                 this::getDirectPresenceTerritories,
                 this::resetDirectPresenceTerritories))
         .put("alliedPresenceTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setAlliedPresenceTerritories,
                 this::setAlliedPresenceTerritories,
                 this::getAlliedPresenceTerritories,
                 this::resetAlliedPresenceTerritories))
         .put("enemyPresenceTerritories",
             MutableProperty.of(
+                String[].class,
                 this::setEnemyPresenceTerritories,
                 this::setEnemyPresenceTerritories,
                 this::getEnemyPresenceTerritories,
                 this::resetEnemyPresenceTerritories))
         .put("unitPresence",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setUnitPresence,
                 this::setUnitPresence,
                 this::getUnitPresence,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1402,29 +1402,25 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::getProductionBonus,
                 this::resetProductionBonus))
         .put("minimumTerritoryValueForProductionBonus",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::getMinimumTerritoryValueForProductionBonus,
                 this::resetMinimumTerritoryValueForProductionBonus))
         .put("repairDiscount",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setRepairDiscount,
                 this::setRepairDiscount,
                 this::getRepairDiscount,
                 this::resetRepairDiscount))
         .put("warBondDiceSides",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setWarBondDiceSides,
                 this::setWarBondDiceSides,
                 this::getWarBondDiceSides,
                 this::resetWarBondDiceSides))
         .put("warBondDiceNumber",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setWarBondDiceNumber,
                 this::setWarBondDiceNumber,
                 this::getWarBondDiceNumber,
@@ -1437,15 +1433,13 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::getRocketDiceNumber,
                 this::resetRocketDiceNumber))
         .put("rocketDistance",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setRocketDistance,
                 this::setRocketDistance,
                 this::getRocketDistance,
                 this::resetRocketDistance))
         .put("rocketNumberPerTerritory",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setRocketNumberPerTerritory,
                 this::setRocketNumberPerTerritory,
                 this::getRocketNumberPerTerritory,
@@ -1458,8 +1452,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::getUnitAbilitiesGained,
                 this::resetUnitAbilitiesGained))
         .put("airborneForces",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setAirborneForces,
                 this::setAirborneForces,
                 this::getAirborneForces,
@@ -1479,8 +1472,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::getAirborneTypes,
                 this::resetAirborneTypes))
         .put("airborneDistance",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAirborneDistance,
                 this::setAirborneDistance,
                 this::getAirborneDistance,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1354,144 +1354,168 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("attackBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setAttackBonus,
                 this::setAttackBonus,
                 this::getAttackBonus,
                 this::resetAttackBonus))
         .put("defenseBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setDefenseBonus,
                 this::setDefenseBonus,
                 this::getDefenseBonus,
                 this::resetDefenseBonus))
         .put("movementBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setMovementBonus,
                 this::setMovementBonus,
                 this::getMovementBonus,
                 this::resetMovementBonus))
         .put("radarBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setRadarBonus,
                 this::setRadarBonus,
                 this::getRadarBonus,
                 this::resetRadarBonus))
         .put("airAttackBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setAirAttackBonus,
                 this::setAirAttackBonus,
                 this::getAirAttackBonus,
                 this::resetAirAttackBonus))
         .put("airDefenseBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setAirDefenseBonus,
                 this::setAirDefenseBonus,
                 this::getAirDefenseBonus,
                 this::resetAirDefenseBonus))
         .put("productionBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setProductionBonus,
                 this::setProductionBonus,
                 this::getProductionBonus,
                 this::resetProductionBonus))
         .put("minimumTerritoryValueForProductionBonus",
             MutableProperty.of(
+                Integer.class,
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::getMinimumTerritoryValueForProductionBonus,
                 this::resetMinimumTerritoryValueForProductionBonus))
         .put("repairDiscount",
             MutableProperty.of(
+                Integer.class,
                 this::setRepairDiscount,
                 this::setRepairDiscount,
                 this::getRepairDiscount,
                 this::resetRepairDiscount))
         .put("warBondDiceSides",
             MutableProperty.of(
+                Integer.class,
                 this::setWarBondDiceSides,
                 this::setWarBondDiceSides,
                 this::getWarBondDiceSides,
                 this::resetWarBondDiceSides))
         .put("warBondDiceNumber",
             MutableProperty.of(
+                Integer.class,
                 this::setWarBondDiceNumber,
                 this::setWarBondDiceNumber,
                 this::getWarBondDiceNumber,
                 this::resetWarBondDiceNumber))
         .put("rocketDiceNumber",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setRocketDiceNumber,
                 this::setRocketDiceNumber,
                 this::getRocketDiceNumber,
                 this::resetRocketDiceNumber))
         .put("rocketDistance",
             MutableProperty.of(
+                Integer.class,
                 this::setRocketDistance,
                 this::setRocketDistance,
                 this::getRocketDistance,
                 this::resetRocketDistance))
         .put("rocketNumberPerTerritory",
             MutableProperty.of(
+                Integer.class,
                 this::setRocketNumberPerTerritory,
                 this::setRocketNumberPerTerritory,
                 this::getRocketNumberPerTerritory,
                 this::resetRocketNumberPerTerritory))
         .put("unitAbilitiesGained",
             MutableProperty.of(
+                Map.class,
                 this::setUnitAbilitiesGained,
                 this::setUnitAbilitiesGained,
                 this::getUnitAbilitiesGained,
                 this::resetUnitAbilitiesGained))
         .put("airborneForces",
             MutableProperty.of(
+                Boolean.class,
                 this::setAirborneForces,
                 this::setAirborneForces,
                 this::getAirborneForces,
                 this::resetAirborneForces))
         .put("airborneCapacity",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setAirborneCapacity,
                 this::setAirborneCapacity,
                 this::getAirborneCapacity,
                 this::resetAirborneCapacity))
         .put("airborneTypes",
             MutableProperty.of(
+                Set.class,
                 this::setAirborneTypes,
                 this::setAirborneTypes,
                 this::getAirborneTypes,
                 this::resetAirborneTypes))
         .put("airborneDistance",
             MutableProperty.of(
+                Integer.class,
                 this::setAirborneDistance,
                 this::setAirborneDistance,
                 this::getAirborneDistance,
                 this::resetAirborneDistance))
         .put("airborneBases",
             MutableProperty.of(
+                Set.class,
                 this::setAirborneBases,
                 this::setAirborneBases,
                 this::getAirborneBases,
                 this::resetAirborneBases))
         .put("airborneTargettedByAA",
             MutableProperty.of(
+                Map.class,
                 this::setAirborneTargettedByAA,
                 this::setAirborneTargettedByAA,
                 this::getAirborneTargettedByAA,
                 this::resetAirborneTargettedByAA))
         .put("attackRollsBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setAttackRollsBonus,
                 this::setAttackRollsBonus,
                 this::getAttackRollsBonus,
                 this::resetAttackRollsBonus))
         .put("defenseRollsBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setDefenseRollsBonus,
                 this::setDefenseRollsBonus,
                 this::getDefenseRollsBonus,
                 this::resetDefenseRollsBonus))
         .put("bombingBonus",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -426,90 +426,105 @@ public class TechAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("techCost",
             MutableProperty.of(
+                Integer.class,
                 this::setTechCost,
                 this::setTechCost,
                 this::getTechCost,
                 this::resetTechCost))
         .put("heavyBomber",
             MutableProperty.of(
+                Boolean.class,
                 this::setHeavyBomber,
                 this::setHeavyBomber,
                 this::getHeavyBomber,
                 this::resetHeavyBomber))
         .put("longRangeAir",
             MutableProperty.of(
+                Boolean.class,
                 this::setLongRangeAir,
                 this::setLongRangeAir,
                 this::getLongRangeAir,
                 this::resetLongRangeAir))
         .put("jetPower",
             MutableProperty.of(
+                Boolean.class,
                 this::setJetPower,
                 this::setJetPower,
                 this::getJetPower,
                 this::resetJetPower))
         .put("rocket",
             MutableProperty.of(
+                Boolean.class,
                 this::setRocket,
                 this::setRocket,
                 this::getRocket,
                 this::resetRocket))
         .put("industrialTechnology",
             MutableProperty.of(
+                Boolean.class,
                 this::setIndustrialTechnology,
                 this::setIndustrialTechnology,
                 this::getIndustrialTechnology,
                 this::resetIndustrialTechnology))
         .put("superSub",
             MutableProperty.of(
+                Boolean.class,
                 this::setSuperSub,
                 this::setSuperSub,
                 this::getSuperSub,
                 this::resetSuperSub))
         .put("destroyerBombard",
             MutableProperty.of(
+                Boolean.class,
                 this::setDestroyerBombard,
                 this::setDestroyerBombard,
                 this::getDestroyerBombard,
                 this::resetDestroyerBombard))
         .put("improvedArtillerySupport",
             MutableProperty.of(
+                Boolean.class,
                 this::setImprovedArtillerySupport,
                 this::setImprovedArtillerySupport,
                 this::getImprovedArtillerySupport,
                 this::resetImprovedArtillerySupport))
         .put("paratroopers",
             MutableProperty.of(
+                Boolean.class,
                 this::setParatroopers,
                 this::setParatroopers,
                 this::getParatroopers,
                 this::resetParatroopers))
         .put("increasedFactoryProduction",
             MutableProperty.of(
+                Boolean.class,
                 this::setIncreasedFactoryProduction,
                 this::setIncreasedFactoryProduction,
                 this::getIncreasedFactoryProduction,
                 this::resetIncreasedFactoryProduction))
         .put("warBonds",
             MutableProperty.of(
+                Boolean.class,
                 this::setWarBonds,
                 this::setWarBonds,
                 this::getWarBonds,
                 this::resetWarBonds))
         .put("mechanizedInfantry",
             MutableProperty.of(
+                Boolean.class,
                 this::setMechanizedInfantry,
                 this::setMechanizedInfantry,
                 this::getMechanizedInfantry,
                 this::resetMechanizedInfantry))
         .put("aARadar",
             MutableProperty.of(
+                Boolean.class,
                 this::setAARadar,
                 this::setAARadar,
                 this::getAARadar,
                 this::resetAARadar))
         .put("shipyards",
             MutableProperty.of(
+                Boolean.class,
                 this::setShipyards,
                 this::setShipyards,
                 this::getShipyards,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -425,106 +425,91 @@ public class TechAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("techCost",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setTechCost,
                 this::setTechCost,
                 this::getTechCost,
                 this::resetTechCost))
         .put("heavyBomber",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setHeavyBomber,
                 this::setHeavyBomber,
                 this::getHeavyBomber,
                 this::resetHeavyBomber))
         .put("longRangeAir",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setLongRangeAir,
                 this::setLongRangeAir,
                 this::getLongRangeAir,
                 this::resetLongRangeAir))
         .put("jetPower",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setJetPower,
                 this::setJetPower,
                 this::getJetPower,
                 this::resetJetPower))
         .put("rocket",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setRocket,
                 this::setRocket,
                 this::getRocket,
                 this::resetRocket))
         .put("industrialTechnology",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIndustrialTechnology,
                 this::setIndustrialTechnology,
                 this::getIndustrialTechnology,
                 this::resetIndustrialTechnology))
         .put("superSub",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setSuperSub,
                 this::setSuperSub,
                 this::getSuperSub,
                 this::resetSuperSub))
         .put("destroyerBombard",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setDestroyerBombard,
                 this::setDestroyerBombard,
                 this::getDestroyerBombard,
                 this::resetDestroyerBombard))
         .put("improvedArtillerySupport",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setImprovedArtillerySupport,
                 this::setImprovedArtillerySupport,
                 this::getImprovedArtillerySupport,
                 this::resetImprovedArtillerySupport))
         .put("paratroopers",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setParatroopers,
                 this::setParatroopers,
                 this::getParatroopers,
                 this::resetParatroopers))
         .put("increasedFactoryProduction",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIncreasedFactoryProduction,
                 this::setIncreasedFactoryProduction,
                 this::getIncreasedFactoryProduction,
                 this::resetIncreasedFactoryProduction))
         .put("warBonds",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setWarBonds,
                 this::setWarBonds,
                 this::getWarBonds,
                 this::resetWarBonds))
         .put("mechanizedInfantry",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setMechanizedInfantry,
                 this::setMechanizedInfantry,
                 this::getMechanizedInfantry,
                 this::resetMechanizedInfantry))
         .put("aARadar",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setAARadar,
                 this::setAARadar,
                 this::getAARadar,
                 this::resetAARadar))
         .put("shipyards",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setShipyards,
                 this::setShipyards,
                 this::getShipyards,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -831,15 +831,13 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getCapital,
                 this::resetCapital))
         .put("originalFactory",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setOriginalFactory,
                 this::setOriginalFactory,
                 this::getOriginalFactory,
                 this::resetOriginalFactory))
         .put("production",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setProduction,
                 this::setProduction,
                 this::getProduction,
@@ -848,15 +846,13 @@ public class TerritoryAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setProductionOnly))
         .put("victoryCity",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setVictoryCity,
                 this::setVictoryCity,
                 this::getVictoryCity,
                 this::resetVictoryCity))
         .put("isImpassable",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsImpassable,
                 this::setIsImpassable,
                 this::getIsImpassable,
@@ -869,8 +865,7 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getOriginalOwner,
                 this::resetOriginalOwner))
         .put("convoyRoute",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setConvoyRoute,
                 this::setConvoyRoute,
                 this::getConvoyRoute,
@@ -897,36 +892,31 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("navalBase",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setNavalBase,
                 this::setNavalBase,
                 this::getNavalBase,
                 this::resetNavalBase))
         .put("airBase",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setAirBase,
                 this::setAirBase,
                 this::getAirBase,
                 this::resetAirBase))
         .put("kamikazeZone",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setKamikazeZone,
                 this::setKamikazeZone,
                 this::getKamikazeZone,
                 this::resetKamikazeZone))
         .put("unitProduction",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setUnitProduction,
                 this::setUnitProduction,
                 this::getUnitProduction,
                 this::resetUnitProduction))
         .put("blockadeZone",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setBlockadeZone,
                 this::setBlockadeZone,
                 this::getBlockadeZone,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -826,19 +826,20 @@ public class TerritoryAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("capital",
-            MutableProperty.of(
-                this::setCapital,
+            MutableProperty.ofString(
                 this::setCapital,
                 this::getCapital,
                 this::resetCapital))
         .put("originalFactory",
             MutableProperty.of(
+                Boolean.class,
                 this::setOriginalFactory,
                 this::setOriginalFactory,
                 this::getOriginalFactory,
                 this::resetOriginalFactory))
         .put("production",
             MutableProperty.of(
+                Integer.class,
                 this::setProduction,
                 this::setProduction,
                 this::getProduction,
@@ -848,90 +849,105 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::setProductionOnly))
         .put("victoryCity",
             MutableProperty.of(
+                Integer.class,
                 this::setVictoryCity,
                 this::setVictoryCity,
                 this::getVictoryCity,
                 this::resetVictoryCity))
         .put("isImpassable",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsImpassable,
                 this::setIsImpassable,
                 this::getIsImpassable,
                 this::resetIsImpassable))
         .put("originalOwner",
             MutableProperty.of(
+                PlayerID.class,
                 this::setOriginalOwner,
                 this::setOriginalOwner,
                 this::getOriginalOwner,
                 this::resetOriginalOwner))
         .put("convoyRoute",
             MutableProperty.of(
+                Boolean.class,
                 this::setConvoyRoute,
                 this::setConvoyRoute,
                 this::getConvoyRoute,
                 this::resetConvoyRoute))
         .put("convoyAttached",
             MutableProperty.of(
+                HashSet.class,
                 this::setConvoyAttached,
                 this::setConvoyAttached,
                 this::getConvoyAttached,
                 this::resetConvoyAttached))
         .put("changeUnitOwners",
             MutableProperty.of(
+                ArrayList.class,
                 this::setChangeUnitOwners,
                 this::setChangeUnitOwners,
                 this::getChangeUnitOwners,
                 this::resetChangeUnitOwners))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
+                ArrayList.class,
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("navalBase",
             MutableProperty.of(
+                Boolean.class,
                 this::setNavalBase,
                 this::setNavalBase,
                 this::getNavalBase,
                 this::resetNavalBase))
         .put("airBase",
             MutableProperty.of(
+                Boolean.class,
                 this::setAirBase,
                 this::setAirBase,
                 this::getAirBase,
                 this::resetAirBase))
         .put("kamikazeZone",
             MutableProperty.of(
+                Boolean.class,
                 this::setKamikazeZone,
                 this::setKamikazeZone,
                 this::getKamikazeZone,
                 this::resetKamikazeZone))
         .put("unitProduction",
             MutableProperty.of(
+                Integer.class,
                 this::setUnitProduction,
                 this::setUnitProduction,
                 this::getUnitProduction,
                 this::resetUnitProduction))
         .put("blockadeZone",
             MutableProperty.of(
+                Boolean.class,
                 this::setBlockadeZone,
                 this::setBlockadeZone,
                 this::getBlockadeZone,
                 this::resetBlockadeZone))
         .put("territoryEffect",
             MutableProperty.of(
+                ArrayList.class,
                 this::setTerritoryEffect,
                 this::setTerritoryEffect,
                 this::getTerritoryEffect,
                 this::resetTerritoryEffect))
         .put("whenCapturedByGoesTo",
             MutableProperty.of(
+                ArrayList.class,
                 this::setWhenCapturedByGoesTo,
                 this::setWhenCapturedByGoesTo,
                 this::getWhenCapturedByGoesTo,
                 this::resetWhenCapturedByGoesTo))
         .put("resources",
             MutableProperty.of(
+                ResourceCollection.class,
                 this::setResources,
                 this::setResources,
                 this::getResources,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -203,24 +203,28 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("combatDefenseEffect",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setCombatDefenseEffect,
                 this::setCombatDefenseEffect,
                 this::getCombatDefenseEffect,
                 this::resetCombatDefenseEffect))
         .put("combatOffenseEffect",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setCombatOffenseEffect,
                 this::setCombatOffenseEffect,
                 this::getCombatOffenseEffect,
                 this::resetCombatOffenseEffect))
         .put("noBlitz",
             MutableProperty.of(
+                List.class,
                 this::setNoBlitz,
                 this::setNoBlitz,
                 this::getNoBlitz,
                 this::resetNoBlitz))
         .put("unitsNotAllowed",
             MutableProperty.of(
+                List.class,
                 this::setUnitsNotAllowed,
                 this::setUnitsNotAllowed,
                 this::getUnitsNotAllowed,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2668,8 +2668,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::getResource,
                 this::resetResource))
         .put("resourceCount",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setResourceCount,
                 this::setResourceCount,
                 this::getResourceCount,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2615,174 +2615,199 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         .putAll(super.getPropertyMap())
         .put("frontier",
             MutableProperty.of(
+                ProductionFrontier.class,
                 this::setFrontier,
                 this::setFrontier,
                 this::getFrontier,
                 this::resetFrontier))
         .put("productionRule",
             MutableProperty.of(
+                List.class,
                 this::setProductionRule,
                 this::setProductionRule,
                 this::getProductionRule,
                 this::resetProductionRule))
         .put("tech",
             MutableProperty.of(
+                List.class,
                 this::setTech,
                 this::setTech,
                 this::getTech,
                 this::resetTech))
         .put("availableTech",
             MutableProperty.of(
+                Map.class,
                 this::setAvailableTech,
                 this::setAvailableTech,
                 this::getAvailableTech,
                 this::resetAvailableTech))
         .put("placement",
             MutableProperty.of(
+                Map.class,
                 this::setPlacement,
                 this::setPlacement,
                 this::getPlacement,
                 this::resetPlacement))
         .put("removeUnits",
             MutableProperty.of(
+                Map.class,
                 this::setRemoveUnits,
                 this::setRemoveUnits,
                 this::getRemoveUnits,
                 this::resetRemoveUnits))
         .put("purchase",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setPurchase,
                 this::setPurchase,
                 this::getPurchase,
                 this::resetPurchase))
         .put("resource",
-            MutableProperty.of(
-                this::setResource,
+            MutableProperty.ofString(
                 this::setResource,
                 this::getResource,
                 this::resetResource))
         .put("resourceCount",
             MutableProperty.of(
+                Integer.class,
                 this::setResourceCount,
                 this::setResourceCount,
                 this::getResourceCount,
                 this::resetResourceCount))
         .put("support",
             MutableProperty.of(
+                Map.class,
                 this::setSupport,
                 this::setSupport,
                 this::getSupport,
                 this::resetSupport))
         .put("relationshipChange",
             MutableProperty.of(
+                List.class,
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,
                 this::resetRelationshipChange))
         .put("victory",
-            MutableProperty.of(
-                this::setVictory,
+            MutableProperty.ofString(
                 this::setVictory,
                 this::getVictory,
                 this::resetVictory))
         .put("activateTrigger",
             MutableProperty.of(
+                List.class,
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,
                 this::resetActivateTrigger))
         .put("changeOwnership",
             MutableProperty.of(
+                List.class,
                 this::setChangeOwnership,
                 this::setChangeOwnership,
                 this::getChangeOwnership,
                 this::resetChangeOwnership))
         .put("unitType",
             MutableProperty.of(
+                List.class,
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
         .put("unitAttachmentName",
             MutableProperty.of(
+                Tuple.class,
                 this::setUnitAttachmentName,
                 this::setUnitAttachmentName,
                 this::getUnitAttachmentName,
                 this::resetUnitAttachmentName))
         .put("unitProperty",
             MutableProperty.of(
+                List.class,
                 this::setUnitProperty,
                 this::setUnitProperty,
                 this::getUnitProperty,
                 this::resetUnitProperty))
         .put("territories",
             MutableProperty.of(
+                List.class,
                 this::setTerritories,
                 this::setTerritories,
                 this::getTerritories,
                 this::resetTerritories))
         .put("territoryAttachmentName",
             MutableProperty.of(
+                Tuple.class,
                 this::setTerritoryAttachmentName,
                 this::setTerritoryAttachmentName,
                 this::getTerritoryAttachmentName,
                 this::resetTerritoryAttachmentName))
         .put("territoryProperty",
             MutableProperty.of(
+                List.class,
                 this::setTerritoryProperty,
                 this::setTerritoryProperty,
                 this::getTerritoryProperty,
                 this::resetTerritoryProperty))
         .put("players",
             MutableProperty.of(
+                List.class,
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("playerAttachmentName",
             MutableProperty.of(
+                Tuple.class,
                 this::setPlayerAttachmentName,
                 this::setPlayerAttachmentName,
                 this::getPlayerAttachmentName,
                 this::resetPlayerAttachmentName))
         .put("playerProperty",
             MutableProperty.of(
+                List.class,
                 this::setPlayerProperty,
                 this::setPlayerProperty,
                 this::getPlayerProperty,
                 this::resetPlayerProperty))
         .put("relationshipTypes",
             MutableProperty.of(
+                List.class,
                 this::setRelationshipTypes,
                 this::setRelationshipTypes,
                 this::getRelationshipTypes,
                 this::resetRelationshipTypes))
         .put("relationshipTypeAttachmentName",
             MutableProperty.of(
+                Tuple.class,
                 this::setRelationshipTypeAttachmentName,
                 this::setRelationshipTypeAttachmentName,
                 this::getRelationshipTypeAttachmentName,
                 this::resetRelationshipTypeAttachmentName))
         .put("relationshipTypeProperty",
             MutableProperty.of(
+                List.class,
                 this::setRelationshipTypeProperty,
                 this::setRelationshipTypeProperty,
                 this::getRelationshipTypeProperty,
                 this::resetRelationshipTypeProperty))
         .put("territoryEffects",
             MutableProperty.of(
+                List.class,
                 this::setTerritoryEffects,
                 this::setTerritoryEffects,
                 this::getTerritoryEffects,
                 this::resetTerritoryEffects))
         .put("territoryEffectAttachmentName",
             MutableProperty.of(
+                Tuple.class,
                 this::setTerritoryEffectAttachmentName,
                 this::setTerritoryEffectAttachmentName,
                 this::getTerritoryEffectAttachmentName,
                 this::resetTerritoryEffectAttachmentName))
         .put("territoryEffectProperty",
             MutableProperty.of(
+                List.class,
                 this::setTerritoryEffectProperty,
                 this::setTerritoryEffectProperty,
                 this::getTerritoryEffectProperty,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3521,8 +3521,7 @@ public class UnitAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("isAir",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAir,
                 this::setIsAir,
                 this::getIsAir,
@@ -3534,29 +3533,25 @@ public class UnitAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setIsParatroop))
         .put("isSea",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsSea,
                 this::setIsSea,
                 this::getIsSea,
                 this::resetIsSea))
         .put("movement",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMovement,
                 this::setMovement,
                 this::getMovement,
                 this::resetMovement))
         .put("canBlitz",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanBlitz,
                 this::setCanBlitz,
                 this::getCanBlitz,
                 this::resetCanBlitz))
         .put("isKamikaze",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsKamikaze,
                 this::setIsKamikaze,
                 this::getIsKamikaze,
@@ -3576,8 +3571,7 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getFuelCost,
                 this::resetFuelCost))
         .put("canNotMoveDuringCombatMove",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanNotMoveDuringCombatMove,
                 this::setCanNotMoveDuringCombatMove,
                 this::getCanNotMoveDuringCombatMove,
@@ -3590,92 +3584,79 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attack",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttack,
                 this::setAttack,
                 this::getAttack,
                 this::resetAttack))
         .put("defense",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setDefense,
                 this::setDefense,
                 this::getDefense,
                 this::resetDefense))
         .put("isInfrastructure",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsInfrastructure,
                 this::setIsInfrastructure,
                 this::getIsInfrastructure,
                 this::resetIsInfrastructure))
         .put("canBombard",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanBombard,
                 this::setCanBombard,
                 this::getCanBombard,
                 this::resetCanBombard))
         .put("bombard",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setBombard,
                 this::setBombard,
                 this::getBombard,
                 this::resetBombard))
         .put("isSub",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsSub,
                 this::setIsSub,
                 this::getIsSub,
                 this::resetIsSub))
         .put("isDestroyer",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsDestroyer,
                 this::setIsDestroyer,
                 this::getIsDestroyer,
                 this::resetIsDestroyer))
         .put("artillery",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setArtillery,
                 this::setArtillery,
                 this::getArtillery,
                 this::resetArtillery))
         .put("artillerySupportable",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setArtillerySupportable,
                 this::setArtillerySupportable,
                 this::getArtillerySupportable,
                 this::resetArtillerySupportable))
         .put("unitSupportCount",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setUnitSupportCount,
                 this::setUnitSupportCount,
                 this::getUnitSupportCount,
                 this::resetUnitSupportCount))
         .put("isMarine",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setIsMarine,
                 this::setIsMarine,
                 this::getIsMarine,
                 this::resetIsMarine))
         .put("isSuicide",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsSuicide,
                 this::setIsSuicide,
                 this::getIsSuicide,
                 this::resetIsSuicide))
         .put("isSuicideOnHit",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsSuicideOnHit,
                 this::setIsSuicideOnHit,
                 this::getIsSuicideOnHit,
@@ -3688,162 +3669,139 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getAttackingLimit,
                 this::resetAttackingLimit))
         .put("attackRolls",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttackRolls,
                 this::setAttackRolls,
                 this::getAttackRolls,
                 this::resetAttackRolls))
         .put("defenseRolls",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setDefenseRolls,
                 this::setDefenseRolls,
                 this::getDefenseRolls,
                 this::resetDefenseRolls))
         .put("chooseBestRoll",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setChooseBestRoll,
                 this::setChooseBestRoll,
                 this::getChooseBestRoll,
                 this::resetChooseBestRoll))
         .put("isCombatTransport",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsCombatTransport,
                 this::setIsCombatTransport,
                 this::getIsCombatTransport,
                 this::resetIsCombatTransport))
         .put("transportCapacity",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setTransportCapacity,
                 this::setTransportCapacity,
                 this::getTransportCapacity,
                 this::resetTransportCapacity))
         .put("transportCost",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setTransportCost,
                 this::setTransportCost,
                 this::getTransportCost,
                 this::resetTransportCost))
         .put("carrierCapacity",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCarrierCapacity,
                 this::setCarrierCapacity,
                 this::getCarrierCapacity,
                 this::resetCarrierCapacity))
         .put("carrierCost",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCarrierCost,
                 this::setCarrierCost,
                 this::getCarrierCost,
                 this::resetCarrierCost))
         .put("isAirTransport",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAirTransport,
                 this::setIsAirTransport,
                 this::getIsAirTransport,
                 this::resetIsAirTransport))
         .put("isAirTransportable",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAirTransportable,
                 this::setIsAirTransportable,
                 this::getIsAirTransportable,
                 this::resetIsAirTransportable))
         .put("isInfantry",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsInfantry,
                 this::setIsInfantry,
                 this::getIsInfantry,
                 this::resetIsInfantry))
         .put("isLandTransport",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsLandTransport,
                 this::setIsLandTransport,
                 this::getIsLandTransport,
                 this::resetIsLandTransport))
         .put("isLandTransportable",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsLandTransportable,
                 this::setIsLandTransportable,
                 this::getIsLandTransportable,
                 this::resetIsLandTransportable))
         .put("isAAforCombatOnly",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAAforCombatOnly,
                 this::setIsAAforCombatOnly,
                 this::getIsAAforCombatOnly,
                 this::resetIsAAforCombatOnly))
         .put("isAAforBombingThisUnitOnly",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAAforBombingThisUnitOnly,
                 this::setIsAAforBombingThisUnitOnly,
                 this::getIsAAforBombingThisUnitOnly,
                 this::resetIsAAforBombingThisUnitOnly))
         .put("isAAforFlyOverOnly",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAAforFlyOverOnly,
                 this::setIsAAforFlyOverOnly,
                 this::getIsAAforFlyOverOnly,
                 this::resetIsAAforFlyOverOnly))
         .put("isRocket",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsRocket,
                 this::setIsRocket,
                 this::getIsRocket,
                 this::resetIsRocket))
         .put("attackAA",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttackAA,
                 this::setAttackAA,
                 this::getAttackAA,
                 this::resetAttackAA))
         .put("offensiveAttackAA",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setOffensiveAttackAA,
                 this::setOffensiveAttackAA,
                 this::getOffensiveAttackAA,
                 this::resetOffensiveAttackAA))
         .put("attackAAmaxDieSides",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAttackAAmaxDieSides,
                 this::setAttackAAmaxDieSides,
                 this::getAttackAAmaxDieSides,
                 this::resetAttackAAmaxDieSides))
         .put("offensiveAttackAAmaxDieSides",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setOffensiveAttackAAmaxDieSides,
                 this::setOffensiveAttackAAmaxDieSides,
                 this::getOffensiveAttackAAmaxDieSides,
                 this::resetOffensiveAttackAAmaxDieSides))
         .put("maxAAattacks",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxAAattacks,
                 this::setMaxAAattacks,
                 this::getMaxAAattacks,
                 this::resetMaxAAattacks))
         .put("maxRoundsAA",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxRoundsAA,
                 this::setMaxRoundsAA,
                 this::getMaxRoundsAA,
@@ -3861,15 +3819,13 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getTargetsAA,
                 this::resetTargetsAA))
         .put("mayOverStackAA",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setMayOverStackAA,
                 this::setMayOverStackAA,
                 this::getMayOverStackAA,
                 this::resetMayOverStackAA))
         .put("damageableAA",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setDamageableAA,
                 this::setDamageableAA,
                 this::getDamageableAA,
@@ -3882,57 +3838,49 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getWillNotFireIfPresent,
                 this::resetWillNotFireIfPresent))
         .put("isStrategicBomber",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsStrategicBomber,
                 this::setIsStrategicBomber,
                 this::getIsStrategicBomber,
                 this::resetIsStrategicBomber))
         .put("bombingMaxDieSides",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setBombingMaxDieSides,
                 this::setBombingMaxDieSides,
                 this::getBombingMaxDieSides,
                 this::resetBombingMaxDieSides))
         .put("bombingBonus",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,
                 this::resetBombingBonus))
         .put("canIntercept",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanIntercept,
                 this::setCanIntercept,
                 this::getCanIntercept,
                 this::resetCanIntercept))
         .put("canEscort",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanEscort,
                 this::setCanEscort,
                 this::getCanEscort,
                 this::resetCanEscort))
         .put("canAirBattle",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanAirBattle,
                 this::setCanAirBattle,
                 this::getCanAirBattle,
                 this::resetCanAirBattle))
         .put("airDefense",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAirDefense,
                 this::setAirDefense,
                 this::getAirDefense,
                 this::resetAirDefense))
         .put("airAttack",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setAirAttack,
                 this::setAirAttack,
                 this::getAirAttack,
@@ -3945,15 +3893,13 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getBombingTargets,
                 this::resetBombingTargets))
         .put("canProduceUnits",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanProduceUnits,
                 this::setCanProduceUnits,
                 this::getCanProduceUnits,
                 this::resetCanProduceUnits))
         .put("canProduceXUnits",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCanProduceXUnits,
                 this::setCanProduceXUnits,
                 this::getCanProduceXUnits,
@@ -3973,43 +3919,37 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getCreatesResourcesList,
                 this::resetCreatesResourcesList))
         .put("hitPoints",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setHitPoints,
                 this::setHitPoints,
                 this::getHitPoints,
                 this::resetHitPoints))
         .put("canBeDamaged",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanBeDamaged,
                 this::setCanBeDamaged,
                 this::getCanBeDamaged,
                 this::resetCanBeDamaged))
         .put("maxDamage",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxDamage,
                 this::setMaxDamage,
                 this::getMaxDamage,
                 this::resetMaxDamage))
         .put("maxOperationalDamage",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxOperationalDamage,
                 this::setMaxOperationalDamage,
                 this::getMaxOperationalDamage,
                 this::resetMaxOperationalDamage))
         .put("canDieFromReachingMaxDamage",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanDieFromReachingMaxDamage,
                 this::setCanDieFromReachingMaxDamage,
                 this::getCanDieFromReachingMaxDamage,
                 this::resetCanDieFromReachingMaxDamage))
         .put("isConstruction",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsConstruction,
                 this::setIsConstruction,
                 this::getIsConstruction,
@@ -4020,22 +3960,19 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getConstructionType,
                 this::resetConstructionType))
         .put("constructionsPerTerrPerTypePerTurn",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::getConstructionsPerTerrPerTypePerTurn,
                 this::resetConstructionsPerTerrPerTypePerTurn))
         .put("maxConstructionsPerTypePerTerr",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxConstructionsPerTypePerTerr,
                 this::setMaxConstructionsPerTypePerTerr,
                 this::getMaxConstructionsPerTypePerTerr,
                 this::resetMaxConstructionsPerTypePerTerr))
         .put("canOnlyBePlacedInTerritoryValuedAtX",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::getCanOnlyBePlacedInTerritoryValuedAtX,
@@ -4069,8 +4006,7 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getUnitPlacementRestrictions,
                 this::resetUnitPlacementRestrictions))
         .put("maxBuiltPerPlayer",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxBuiltPerPlayer,
                 this::setMaxBuiltPerPlayer,
                 this::getMaxBuiltPerPlayer,
@@ -4083,36 +4019,31 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("canScramble",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setCanScramble,
                 this::setCanScramble,
                 this::getCanScramble,
                 this::resetCanScramble))
         .put("isAirBase",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setIsAirBase,
                 this::setIsAirBase,
                 this::getIsAirBase,
                 this::resetIsAirBase))
         .put("maxScrambleDistance",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxScrambleDistance,
                 this::setMaxScrambleDistance,
                 this::getMaxScrambleDistance,
                 this::resetMaxScrambleDistance))
         .put("maxScrambleCount",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setMaxScrambleCount,
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount,
                 this::resetMaxScrambleCount))
         .put("blockade",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setBlockade,
                 this::setBlockade,
                 this::getBlockade,
@@ -4160,8 +4091,7 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getWhenCapturedChangesInto,
                 this::resetWhenCapturedChangesInto))
         .put("whenCapturedSustainsDamage",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setWhenCapturedSustainsDamage,
                 this::setWhenCapturedSustainsDamage,
                 this::getWhenCapturedSustainsDamage,
@@ -4202,20 +4132,17 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getSpecial,
                 this::resetSpecial))
         .put("tuv",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setTuv,
                 this::setTuv,
                 this::getTuv,
                 this::resetTuv))
         .put("isFactory",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofWriteOnlyBoolean(
                 this::setIsFactory,
                 this::setIsFactory))
         .put("isAA",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofWriteOnlyBoolean(
                 this::setIsAA,
                 this::setIsAA))
         .put("destroyedWhenCapturedFrom",
@@ -4229,13 +4156,11 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setUnitPlacementOnlyAllowedIn,
                 this::setUnitPlacementOnlyAllowedIn))
         .put("isAAmovement",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofWriteOnlyBoolean(
                 this::setIsAAmovement,
                 this::setIsAAmovement))
         .put("isTwoHit",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofWriteOnlyBoolean(
                 this::setIsTwoHit,
                 this::setIsTwoHit))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3522,6 +3522,7 @@ public class UnitAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("isAir",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAir,
                 this::setIsAir,
                 this::getIsAir,
@@ -3534,600 +3535,709 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsParatroop))
         .put("isSea",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsSea,
                 this::setIsSea,
                 this::getIsSea,
                 this::resetIsSea))
         .put("movement",
             MutableProperty.of(
+                Integer.class,
                 this::setMovement,
                 this::setMovement,
                 this::getMovement,
                 this::resetMovement))
         .put("canBlitz",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanBlitz,
                 this::setCanBlitz,
                 this::getCanBlitz,
                 this::resetCanBlitz))
         .put("isKamikaze",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsKamikaze,
                 this::setIsKamikaze,
                 this::getIsKamikaze,
                 this::resetIsKamikaze))
         .put("canInvadeOnlyFrom",
             MutableProperty.of(
+                String[].class,
                 this::setCanInvadeOnlyFrom,
                 this::setCanInvadeOnlyFrom,
                 this::getCanInvadeOnlyFrom,
                 this::resetCanInvadeOnlyFrom))
         .put("fuelCost",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setFuelCost,
                 this::setFuelCost,
                 this::getFuelCost,
                 this::resetFuelCost))
         .put("canNotMoveDuringCombatMove",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanNotMoveDuringCombatMove,
                 this::setCanNotMoveDuringCombatMove,
                 this::getCanNotMoveDuringCombatMove,
                 this::resetCanNotMoveDuringCombatMove))
         .put("movementLimit",
             MutableProperty.of(
+                Tuple.class,
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attack",
             MutableProperty.of(
+                Integer.class,
                 this::setAttack,
                 this::setAttack,
                 this::getAttack,
                 this::resetAttack))
         .put("defense",
             MutableProperty.of(
+                Integer.class,
                 this::setDefense,
                 this::setDefense,
                 this::getDefense,
                 this::resetDefense))
         .put("isInfrastructure",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsInfrastructure,
                 this::setIsInfrastructure,
                 this::getIsInfrastructure,
                 this::resetIsInfrastructure))
         .put("canBombard",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanBombard,
                 this::setCanBombard,
                 this::getCanBombard,
                 this::resetCanBombard))
         .put("bombard",
             MutableProperty.of(
+                Integer.class,
                 this::setBombard,
                 this::setBombard,
                 this::getBombard,
                 this::resetBombard))
         .put("isSub",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsSub,
                 this::setIsSub,
                 this::getIsSub,
                 this::resetIsSub))
         .put("isDestroyer",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsDestroyer,
                 this::setIsDestroyer,
                 this::getIsDestroyer,
                 this::resetIsDestroyer))
         .put("artillery",
             MutableProperty.of(
+                Boolean.class,
                 this::setArtillery,
                 this::setArtillery,
                 this::getArtillery,
                 this::resetArtillery))
         .put("artillerySupportable",
             MutableProperty.of(
+                Boolean.class,
                 this::setArtillerySupportable,
                 this::setArtillerySupportable,
                 this::getArtillerySupportable,
                 this::resetArtillerySupportable))
         .put("unitSupportCount",
             MutableProperty.of(
+                Integer.class,
                 this::setUnitSupportCount,
                 this::setUnitSupportCount,
                 this::getUnitSupportCount,
                 this::resetUnitSupportCount))
         .put("isMarine",
             MutableProperty.of(
+                Integer.class,
                 this::setIsMarine,
                 this::setIsMarine,
                 this::getIsMarine,
                 this::resetIsMarine))
         .put("isSuicide",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsSuicide,
                 this::setIsSuicide,
                 this::getIsSuicide,
                 this::resetIsSuicide))
         .put("isSuicideOnHit",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsSuicideOnHit,
                 this::setIsSuicideOnHit,
                 this::getIsSuicideOnHit,
                 this::resetIsSuicideOnHit))
         .put("attackingLimit",
             MutableProperty.of(
+                Tuple.class,
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,
                 this::resetAttackingLimit))
         .put("attackRolls",
             MutableProperty.of(
+                Integer.class,
                 this::setAttackRolls,
                 this::setAttackRolls,
                 this::getAttackRolls,
                 this::resetAttackRolls))
         .put("defenseRolls",
             MutableProperty.of(
+                Integer.class,
                 this::setDefenseRolls,
                 this::setDefenseRolls,
                 this::getDefenseRolls,
                 this::resetDefenseRolls))
         .put("chooseBestRoll",
             MutableProperty.of(
+                Boolean.class,
                 this::setChooseBestRoll,
                 this::setChooseBestRoll,
                 this::getChooseBestRoll,
                 this::resetChooseBestRoll))
         .put("isCombatTransport",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsCombatTransport,
                 this::setIsCombatTransport,
                 this::getIsCombatTransport,
                 this::resetIsCombatTransport))
         .put("transportCapacity",
             MutableProperty.of(
+                Integer.class,
                 this::setTransportCapacity,
                 this::setTransportCapacity,
                 this::getTransportCapacity,
                 this::resetTransportCapacity))
         .put("transportCost",
             MutableProperty.of(
+                Integer.class,
                 this::setTransportCost,
                 this::setTransportCost,
                 this::getTransportCost,
                 this::resetTransportCost))
         .put("carrierCapacity",
             MutableProperty.of(
+                Integer.class,
                 this::setCarrierCapacity,
                 this::setCarrierCapacity,
                 this::getCarrierCapacity,
                 this::resetCarrierCapacity))
         .put("carrierCost",
             MutableProperty.of(
+                Integer.class,
                 this::setCarrierCost,
                 this::setCarrierCost,
                 this::getCarrierCost,
                 this::resetCarrierCost))
         .put("isAirTransport",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAirTransport,
                 this::setIsAirTransport,
                 this::getIsAirTransport,
                 this::resetIsAirTransport))
         .put("isAirTransportable",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAirTransportable,
                 this::setIsAirTransportable,
                 this::getIsAirTransportable,
                 this::resetIsAirTransportable))
         .put("isInfantry",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsInfantry,
                 this::setIsInfantry,
                 this::getIsInfantry,
                 this::resetIsInfantry))
         .put("isLandTransport",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsLandTransport,
                 this::setIsLandTransport,
                 this::getIsLandTransport,
                 this::resetIsLandTransport))
         .put("isLandTransportable",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsLandTransportable,
                 this::setIsLandTransportable,
                 this::getIsLandTransportable,
                 this::resetIsLandTransportable))
         .put("isAAforCombatOnly",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAAforCombatOnly,
                 this::setIsAAforCombatOnly,
                 this::getIsAAforCombatOnly,
                 this::resetIsAAforCombatOnly))
         .put("isAAforBombingThisUnitOnly",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAAforBombingThisUnitOnly,
                 this::setIsAAforBombingThisUnitOnly,
                 this::getIsAAforBombingThisUnitOnly,
                 this::resetIsAAforBombingThisUnitOnly))
         .put("isAAforFlyOverOnly",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAAforFlyOverOnly,
                 this::setIsAAforFlyOverOnly,
                 this::getIsAAforFlyOverOnly,
                 this::resetIsAAforFlyOverOnly))
         .put("isRocket",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsRocket,
                 this::setIsRocket,
                 this::getIsRocket,
                 this::resetIsRocket))
         .put("attackAA",
             MutableProperty.of(
+                Integer.class,
                 this::setAttackAA,
                 this::setAttackAA,
                 this::getAttackAA,
                 this::resetAttackAA))
         .put("offensiveAttackAA",
             MutableProperty.of(
+                Integer.class,
                 this::setOffensiveAttackAA,
                 this::setOffensiveAttackAA,
                 this::getOffensiveAttackAA,
                 this::resetOffensiveAttackAA))
         .put("attackAAmaxDieSides",
             MutableProperty.of(
+                Integer.class,
                 this::setAttackAAmaxDieSides,
                 this::setAttackAAmaxDieSides,
                 this::getAttackAAmaxDieSides,
                 this::resetAttackAAmaxDieSides))
         .put("offensiveAttackAAmaxDieSides",
             MutableProperty.of(
+                Integer.class,
                 this::setOffensiveAttackAAmaxDieSides,
                 this::setOffensiveAttackAAmaxDieSides,
                 this::getOffensiveAttackAAmaxDieSides,
                 this::resetOffensiveAttackAAmaxDieSides))
         .put("maxAAattacks",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxAAattacks,
                 this::setMaxAAattacks,
                 this::getMaxAAattacks,
                 this::resetMaxAAattacks))
         .put("maxRoundsAA",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxRoundsAA,
                 this::setMaxRoundsAA,
                 this::getMaxRoundsAA,
                 this::resetMaxRoundsAA))
         .put("typeAA",
-            MutableProperty.of(
-                this::setTypeAA,
+            MutableProperty.ofString(
                 this::setTypeAA,
                 this::getTypeAA,
                 this::resetTypeAA))
         .put("targetsAA",
             MutableProperty.of(
+                Set.class,
                 this::setTargetsAA,
                 this::setTargetsAA,
                 this::getTargetsAA,
                 this::resetTargetsAA))
         .put("mayOverStackAA",
             MutableProperty.of(
+                Boolean.class,
                 this::setMayOverStackAA,
                 this::setMayOverStackAA,
                 this::getMayOverStackAA,
                 this::resetMayOverStackAA))
         .put("damageableAA",
             MutableProperty.of(
+                Boolean.class,
                 this::setDamageableAA,
                 this::setDamageableAA,
                 this::getDamageableAA,
                 this::resetDamageableAA))
         .put("willNotFireIfPresent",
             MutableProperty.of(
+                Set.class,
                 this::setWillNotFireIfPresent,
                 this::setWillNotFireIfPresent,
                 this::getWillNotFireIfPresent,
                 this::resetWillNotFireIfPresent))
         .put("isStrategicBomber",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsStrategicBomber,
                 this::setIsStrategicBomber,
                 this::getIsStrategicBomber,
                 this::resetIsStrategicBomber))
         .put("bombingMaxDieSides",
             MutableProperty.of(
+                Integer.class,
                 this::setBombingMaxDieSides,
                 this::setBombingMaxDieSides,
                 this::getBombingMaxDieSides,
                 this::resetBombingMaxDieSides))
         .put("bombingBonus",
             MutableProperty.of(
+                Integer.class,
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,
                 this::resetBombingBonus))
         .put("canIntercept",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanIntercept,
                 this::setCanIntercept,
                 this::getCanIntercept,
                 this::resetCanIntercept))
         .put("canEscort",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanEscort,
                 this::setCanEscort,
                 this::getCanEscort,
                 this::resetCanEscort))
         .put("canAirBattle",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanAirBattle,
                 this::setCanAirBattle,
                 this::getCanAirBattle,
                 this::resetCanAirBattle))
         .put("airDefense",
             MutableProperty.of(
+                Integer.class,
                 this::setAirDefense,
                 this::setAirDefense,
                 this::getAirDefense,
                 this::resetAirDefense))
         .put("airAttack",
             MutableProperty.of(
+                Integer.class,
                 this::setAirAttack,
                 this::setAirAttack,
                 this::getAirAttack,
                 this::resetAirAttack))
         .put("bombingTargets",
             MutableProperty.of(
+                Set.class,
                 this::setBombingTargets,
                 this::setBombingTargets,
                 this::getBombingTargets,
                 this::resetBombingTargets))
         .put("canProduceUnits",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanProduceUnits,
                 this::setCanProduceUnits,
                 this::getCanProduceUnits,
                 this::resetCanProduceUnits))
         .put("canProduceXUnits",
             MutableProperty.of(
+                Integer.class,
                 this::setCanProduceXUnits,
                 this::setCanProduceXUnits,
                 this::getCanProduceXUnits,
                 this::resetCanProduceXUnits))
         .put("createsUnitsList",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setCreatesUnitsList,
                 this::setCreatesUnitsList,
                 this::getCreatesUnitsList,
                 this::resetCreatesUnitsList))
         .put("createsResourcesList",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setCreatesResourcesList,
                 this::setCreatesResourcesList,
                 this::getCreatesResourcesList,
                 this::resetCreatesResourcesList))
         .put("hitPoints",
             MutableProperty.of(
+                Integer.class,
                 this::setHitPoints,
                 this::setHitPoints,
                 this::getHitPoints,
                 this::resetHitPoints))
         .put("canBeDamaged",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanBeDamaged,
                 this::setCanBeDamaged,
                 this::getCanBeDamaged,
                 this::resetCanBeDamaged))
         .put("maxDamage",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxDamage,
                 this::setMaxDamage,
                 this::getMaxDamage,
                 this::resetMaxDamage))
         .put("maxOperationalDamage",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxOperationalDamage,
                 this::setMaxOperationalDamage,
                 this::getMaxOperationalDamage,
                 this::resetMaxOperationalDamage))
         .put("canDieFromReachingMaxDamage",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanDieFromReachingMaxDamage,
                 this::setCanDieFromReachingMaxDamage,
                 this::getCanDieFromReachingMaxDamage,
                 this::resetCanDieFromReachingMaxDamage))
         .put("isConstruction",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsConstruction,
                 this::setIsConstruction,
                 this::getIsConstruction,
                 this::resetIsConstruction))
         .put("constructionType",
-            MutableProperty.of(
-                this::setConstructionType,
+            MutableProperty.ofString(
                 this::setConstructionType,
                 this::getConstructionType,
                 this::resetConstructionType))
         .put("constructionsPerTerrPerTypePerTurn",
             MutableProperty.of(
+                Integer.class,
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::getConstructionsPerTerrPerTypePerTurn,
                 this::resetConstructionsPerTerrPerTypePerTurn))
         .put("maxConstructionsPerTypePerTerr",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxConstructionsPerTypePerTerr,
                 this::setMaxConstructionsPerTypePerTerr,
                 this::getMaxConstructionsPerTypePerTerr,
                 this::resetMaxConstructionsPerTypePerTerr))
         .put("canOnlyBePlacedInTerritoryValuedAtX",
             MutableProperty.of(
+                Integer.class,
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::getCanOnlyBePlacedInTerritoryValuedAtX,
                 this::resetCanOnlyBePlacedInTerritoryValuedAtX))
         .put("requiresUnits",
             MutableProperty.of(
+                List.class,
                 this::setRequiresUnits,
                 this::setRequiresUnits,
                 this::getRequiresUnits,
                 this::resetRequiresUnits))
         .put("consumesUnits",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setConsumesUnits,
                 this::setConsumesUnits,
                 this::getConsumesUnits,
                 this::resetConsumesUnits))
         .put("requiresUnitsToMove",
             MutableProperty.of(
+                List.class,
                 this::setRequiresUnitsToMove,
                 this::setRequiresUnitsToMove,
                 this::getRequiresUnitsToMove,
                 this::resetRequiresUnitsToMove))
         .put("unitPlacementRestrictions",
             MutableProperty.of(
+                String[].class,
                 this::setUnitPlacementRestrictions,
                 this::setUnitPlacementRestrictions,
                 this::getUnitPlacementRestrictions,
                 this::resetUnitPlacementRestrictions))
         .put("maxBuiltPerPlayer",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxBuiltPerPlayer,
                 this::setMaxBuiltPerPlayer,
                 this::getMaxBuiltPerPlayer,
                 this::resetMaxBuiltPerPlayer))
         .put("placementLimit",
             MutableProperty.of(
+                Tuple.class,
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("canScramble",
             MutableProperty.of(
+                Boolean.class,
                 this::setCanScramble,
                 this::setCanScramble,
                 this::getCanScramble,
                 this::resetCanScramble))
         .put("isAirBase",
             MutableProperty.of(
+                Boolean.class,
                 this::setIsAirBase,
                 this::setIsAirBase,
                 this::getIsAirBase,
                 this::resetIsAirBase))
         .put("maxScrambleDistance",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxScrambleDistance,
                 this::setMaxScrambleDistance,
                 this::getMaxScrambleDistance,
                 this::resetMaxScrambleDistance))
         .put("maxScrambleCount",
             MutableProperty.of(
+                Integer.class,
                 this::setMaxScrambleCount,
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount,
                 this::resetMaxScrambleCount))
         .put("blockade",
             MutableProperty.of(
+                Integer.class,
                 this::setBlockade,
                 this::setBlockade,
                 this::getBlockade,
                 this::resetBlockade))
         .put("repairsUnits",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setRepairsUnits,
                 this::setRepairsUnits,
                 this::getRepairsUnits,
                 this::resetRepairsUnits))
         .put("givesMovement",
             MutableProperty.of(
+                IntegerMap.class,
                 this::setGivesMovement,
                 this::setGivesMovement,
                 this::getGivesMovement,
                 this::resetGivesMovement))
         .put("destroyedWhenCapturedBy",
             MutableProperty.of(
+                List.class,
                 this::setDestroyedWhenCapturedBy,
                 this::setDestroyedWhenCapturedBy,
                 this::getDestroyedWhenCapturedBy,
                 this::resetDestroyedWhenCapturedBy))
         .put("whenHitPointsDamagedChangesInto",
             MutableProperty.of(
+                Map.class,
                 this::setWhenHitPointsDamagedChangesInto,
                 this::setWhenHitPointsDamagedChangesInto,
                 this::getWhenHitPointsDamagedChangesInto,
                 this::resetWhenHitPointsDamagedChangesInto))
         .put("whenHitPointsRepairedChangesInto",
             MutableProperty.of(
+                Map.class,
                 this::setWhenHitPointsRepairedChangesInto,
                 this::setWhenHitPointsRepairedChangesInto,
                 this::getWhenHitPointsRepairedChangesInto,
                 this::resetWhenHitPointsRepairedChangesInto))
         .put("whenCapturedChangesInto",
             MutableProperty.of(
+                Map.class,
                 this::setWhenCapturedChangesInto,
                 this::setWhenCapturedChangesInto,
                 this::getWhenCapturedChangesInto,
                 this::resetWhenCapturedChangesInto))
         .put("whenCapturedSustainsDamage",
             MutableProperty.of(
+                Integer.class,
                 this::setWhenCapturedSustainsDamage,
                 this::setWhenCapturedSustainsDamage,
                 this::getWhenCapturedSustainsDamage,
                 this::resetWhenCapturedSustainsDamage))
         .put("canBeCapturedOnEnteringBy",
             MutableProperty.of(
+                List.class,
                 this::setCanBeCapturedOnEnteringBy,
                 this::setCanBeCapturedOnEnteringBy,
                 this::getCanBeCapturedOnEnteringBy,
                 this::resetCanBeCapturedOnEnteringBy))
         .put("canBeGivenByTerritoryTo",
             MutableProperty.of(
+                List.class,
                 this::setCanBeGivenByTerritoryTo,
                 this::setCanBeGivenByTerritoryTo,
                 this::getCanBeGivenByTerritoryTo,
                 this::resetCanBeGivenByTerritoryTo))
         .put("whenCombatDamaged",
             MutableProperty.of(
+                List.class,
                 this::setWhenCombatDamaged,
                 this::setWhenCombatDamaged,
                 this::getWhenCombatDamaged,
                 this::resetWhenCombatDamaged))
         .put("receivesAbilityWhenWith",
             MutableProperty.of(
+                List.class,
                 this::setReceivesAbilityWhenWith,
                 this::setReceivesAbilityWhenWith,
                 this::getReceivesAbilityWhenWith,
                 this::resetReceivesAbilityWhenWith))
         .put("special",
             MutableProperty.of(
+                Set.class,
                 this::setSpecial,
                 this::setSpecial,
                 this::getSpecial,
                 this::resetSpecial))
         .put("tuv",
             MutableProperty.of(
+                Integer.class,
                 this::setTuv,
                 this::setTuv,
                 this::getTuv,
                 this::resetTuv))
         .put("isFactory",
-            MutableProperty.<Boolean>of(
+            MutableProperty.of(
+                Boolean.class,
                 this::setIsFactory,
                 this::setIsFactory))
         .put("isAA",
-            MutableProperty.<Boolean>of(
+            MutableProperty.of(
+                Boolean.class,
                 this::setIsAA,
                 this::setIsAA))
         .put("destroyedWhenCapturedFrom",
-            MutableProperty.of(this::setDestroyedWhenCapturedFrom, this::setDestroyedWhenCapturedFrom))
+            MutableProperty.of(
+                String.class,
+                this::setDestroyedWhenCapturedFrom,
+                this::setDestroyedWhenCapturedFrom))
         .put("unitPlacementOnlyAllowedIn",
-            MutableProperty.of(this::setUnitPlacementOnlyAllowedIn, this::setUnitPlacementOnlyAllowedIn))
-        .put("isAAmovement", MutableProperty.<Boolean>of(this::setIsAAmovement, this::setIsAAmovement))
-        .put("isTwoHit", MutableProperty.<Boolean>of(this::setIsTwoHit, this::setIsTwoHit))
+            MutableProperty.of(
+                String.class,
+                this::setUnitPlacementOnlyAllowedIn,
+                this::setUnitPlacementOnlyAllowedIn))
+        .put("isAAmovement",
+            MutableProperty.of(
+                Boolean.class,
+                this::setIsAAmovement,
+                this::setIsAAmovement))
+        .put("isTwoHit",
+            MutableProperty.of(
+                Boolean.class,
+                this::setIsTwoHit,
+                this::setIsTwoHit))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -425,42 +425,46 @@ public class UnitSupportAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("unitType",
             MutableProperty.of(
+                Set.class,
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
-        .put("offence", MutableProperty.of(this::getOffence))
-        .put("defence", MutableProperty.of(this::getDefence))
-        .put("roll", MutableProperty.of(this::getRoll))
-        .put("strength", MutableProperty.of(this::getStrength))
+        .put("offence", MutableProperty.of(Boolean.class, this::getOffence))
+        .put("defence", MutableProperty.of(Boolean.class, this::getDefence))
+        .put("roll", MutableProperty.of(Boolean.class, this::getRoll))
+        .put("strength", MutableProperty.of(Boolean.class, this::getStrength))
         .put("bonus",
             MutableProperty.of(
+                Integer.class,
                 this::setBonus,
                 this::setBonus,
                 this::getBonus,
                 this::resetBonus))
         .put("number",
             MutableProperty.of(
+                Integer.class,
                 this::setNumber,
                 this::setNumber,
                 this::getNumber,
                 this::resetNumber))
-        .put("allied", MutableProperty.of(this::getAllied))
-        .put("enemy", MutableProperty.of(this::getEnemy))
+        .put("allied", MutableProperty.of(Boolean.class, this::getAllied))
+        .put("enemy", MutableProperty.of(Boolean.class, this::getEnemy))
         .put("bonusType",
-            MutableProperty.of(
-                this::setBonusType,
+            MutableProperty.ofString(
                 this::setBonusType,
                 this::getBonusType,
                 this::resetBonusType))
         .put("players",
             MutableProperty.of(
+                List.class,
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("impArtTech",
             MutableProperty.of(
+                Boolean.class,
                 this::setImpArtTech,
                 this::setImpArtTech,
                 this::getImpArtTech,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -430,26 +430,24 @@ public class UnitSupportAttachment extends DefaultAttachment {
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
-        .put("offence", MutableProperty.of(Boolean.class, this::getOffence))
-        .put("defence", MutableProperty.of(Boolean.class, this::getDefence))
-        .put("roll", MutableProperty.of(Boolean.class, this::getRoll))
-        .put("strength", MutableProperty.of(Boolean.class, this::getStrength))
+        .put("offence", MutableProperty.ofReadOnlyBoolean(this::getOffence))
+        .put("defence", MutableProperty.ofReadOnlyBoolean(this::getDefence))
+        .put("roll", MutableProperty.ofReadOnlyBoolean(this::getRoll))
+        .put("strength", MutableProperty.ofReadOnlyBoolean(this::getStrength))
         .put("bonus",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setBonus,
                 this::setBonus,
                 this::getBonus,
                 this::resetBonus))
         .put("number",
-            MutableProperty.of(
-                Integer.class,
+            MutableProperty.ofInteger(
                 this::setNumber,
                 this::setNumber,
                 this::getNumber,
                 this::resetNumber))
-        .put("allied", MutableProperty.of(Boolean.class, this::getAllied))
-        .put("enemy", MutableProperty.of(Boolean.class, this::getEnemy))
+        .put("allied", MutableProperty.ofReadOnlyBoolean(this::getAllied))
+        .put("enemy", MutableProperty.ofReadOnlyBoolean(this::getEnemy))
         .put("bonusType",
             MutableProperty.ofString(
                 this::setBonusType,
@@ -463,8 +461,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
                 this::getPlayers,
                 this::resetPlayers))
         .put("impArtTech",
-            MutableProperty.of(
-                Boolean.class,
+            MutableProperty.ofBoolean(
                 this::setImpArtTech,
                 this::setImpArtTech,
                 this::getImpArtTech,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -182,6 +182,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
         .putAll(super.getPropertyMap())
         .put("activateTrigger",
             MutableProperty.of(
+                List.class,
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,

--- a/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
@@ -1,0 +1,21 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.MutableProperty.InvalidValueException;
+
+public final class MutablePropertyTest {
+  @Test
+  public void setValue_ShouldThrowExceptionWhenValueHasWrongType() {
+    final MutableProperty<Integer> mutableProperty = MutableProperty.ofSimple(Integer.class, value -> {
+    }, () -> 42);
+
+    final Exception e = assertThrows(InvalidValueException.class, () -> mutableProperty.setValue(new Object()));
+    assertThat(e.getCause(), is(instanceOf(ClassCastException.class)));
+  }
+}


### PR DESCRIPTION
This is a more controversial change than the last one.  It adds a `Class<T>` field to each `MutableProperty` primarily to avoid the unchecked type warnings.  Secondarily, it avoids ambiguity in choosing a factory method type parameter when there are multiple compatible method references, which previously required explicitly specifying the type argument to the factory method (realistically, this probably won't occur very often; there are only four occurrences currently).

I say it's controversial because now it requires the client to specify the property type.  To reduce this burden somewhat, I added additional convenience factory methods for common JDK types, similar to what you had done for `ofString()`.  There's probably a few more that could be added for the JDK collection types `List`, `Map`, and `Set`, as those seem to be used pretty often.  But I think what's here will give you an idea of whether or not this is a good idea.

Having the property type at runtime could also be useful for some of the proposed future changes mentioned in the previous PR since those will require casts at runtime, as well.

Anyway, take a look and let me know what you think.